### PR TITLE
Update Google SDK Version to 2.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+xcuserdata
+.DS_Store
+Carthage

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 5.1.0
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 5.2.0
 binary "https://dl.google.com/geosdk/GooglePlaces.json" == 5.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 5.2.0
-binary "https://dl.google.com/geosdk/GooglePlaces.json" == 5.1.0
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.0.0
+binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.0.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 5.0.0
-binary "https://dl.google.com/geosdk/GooglePlaces.json" == 5.0.0
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 5.1.0
+binary "https://dl.google.com/geosdk/GooglePlaces.json" == 5.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.0.0
-binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.0.0
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.0.0-beta
+binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.0.0-beta

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.1.1-beta
-binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.1.1-beta
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.2.1-beta
+binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.2.1-beta

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.0.0-beta
-binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.0.0-beta
+binary "https://dl.google.com/geosdk/GoogleMaps.json" == 6.1.1-beta
+binary "https://dl.google.com/geosdk/GooglePlaces.json" == 6.1.1-beta

--- a/GoogleMaps-Sim.xcodeproj/project.pbxproj
+++ b/GoogleMaps-Sim.xcodeproj/project.pbxproj
@@ -1,0 +1,1702 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
+		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
+		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
+		8A66400025397D6F000E9321 /* GMSDeprecationMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A66400125397D6F000E9321 /* GoogleMapsBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A66400225397D6F000E9321 /* GMSCompatabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A66400325397D6F000E9321 /* GMSCoordinateBounds.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A66401725397D90000E9321 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A66401325397D90000E9321 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A66408B25397EC3000E9321 /* GoogleMapsBase in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A663FF225397D68000E9321 /* GoogleMapsBase */; };
+		8A66409625397EF2000E9321 /* GoogleMapsM4B in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66401625397D90000E9321 /* GoogleMapsM4B */; };
+		8A6640A125397EFE000E9321 /* GooglePlaces in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66403925397DA0000E9321 /* GooglePlaces */; };
+		8A6640BB253980A2000E9321 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */; };
+		8A6640EE2539820E000E9321 /* GoogleMaps in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A663F7D25397CE4000E9321 /* GoogleMaps */; };
+		8A66410A2539826E000E9321 /* GoogleMapsCore in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66400B25397D7D000E9321 /* GoogleMapsCore */; };
+		8A6641112539828D000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
+		8A664117253982B6000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
+		8A66411E253982C0000E9321 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66411D253982C0000E9321 /* UIKit.framework */; };
+		8A664125253982D1000E9321 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664124253982D0000E9321 /* CoreGraphics.framework */; };
+		8A664127253982D9000E9321 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664126253982D9000E9321 /* CoreLocation.framework */; };
+		8A664135253982F1000E9321 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664134253982F1000E9321 /* CoreTelephony.framework */; };
+		8A66413C253982FB000E9321 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
+		8A66413E25398302000E9321 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413D25398302000E9321 /* CoreText.framework */; };
+		8A66414925398310000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
+		8A66415025398315000E9321 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
+		8A66415625398342000E9321 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66411D253982C0000E9321 /* UIKit.framework */; };
+		8A66416925398367000E9321 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664124253982D0000E9321 /* CoreGraphics.framework */; };
+		8A66417025398371000E9321 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66416F25398371000E9321 /* GLKit.framework */; };
+		8A66417125398376000E9321 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413D25398302000E9321 /* CoreText.framework */; };
+		8A66417825398383000E9321 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66417725398383000E9321 /* OpenGLES.framework */; };
+		8A66417F2539838B000E9321 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66417E2539838B000E9321 /* CoreData.framework */; };
+		8A66418625398396000E9321 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664134253982F1000E9321 /* CoreTelephony.framework */; };
+		8A6641872539839E000E9321 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664126253982D9000E9321 /* CoreLocation.framework */; };
+		8A66418E253983AA000E9321 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66418D253983AA000E9321 /* SystemConfiguration.framework */; };
+		8A6641B2253983ED000E9321 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66418F253983B1000E9321 /* ImageIO.framework */; };
+		8A6641B8253983F6000E9321 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
+		8A6641BE25398406000E9321 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664196253983BC000E9321 /* CoreImage.framework */; };
+		8A6641CE25398410000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
+		8A6641D425398415000E9321 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
+		8A6641DA2539842E000E9321 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */; };
+		8A6641E125398442000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
+		8A6641E225398447000E9321 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66411D253982C0000E9321 /* UIKit.framework */; };
+		8A6641E825398452000E9321 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664124253982D0000E9321 /* CoreGraphics.framework */; };
+		8A6641F425398461000E9321 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A664126253982D9000E9321 /* CoreLocation.framework */; };
+		8A6641FA25398472000E9321 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
+		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
+		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
+		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
+		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
+		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
+		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E526526A8E00C2AD24 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E826526A8F00C2AD24 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EC26526A8F00C2AD24 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082126526A9000C2AD24 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F026526A8F00C2AD24 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F326526A8F00C2AD24 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080026526A8F00C2AD24 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080426526A8F00C2AD24 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080926526A9000C2AD24 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080B26526A9000C2AD24 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080D26526A9000C2AD24 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71083F26526AE800C2AD24 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085A26526AE900C2AD24 /* GMSPlusCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084226526AE900C2AD24 /* GMSPlusCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085B26526AE900C2AD24 /* GMSPlaceViewportInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085C26526AE900C2AD24 /* GMSAutocompletePrediction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085D26526AE900C2AD24 /* GMSAutocompleteFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085E26526AE900C2AD24 /* GMSAutocompleteSessionToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71085F26526AE900C2AD24 /* GMSAutocompleteTableDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086026526AE900C2AD24 /* GMSAutocompleteMatchFragment.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086126526AE900C2AD24 /* GMSPlaceLikelihoodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086226526AE900C2AD24 /* GMSPlacePhotoMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086326526AE900C2AD24 /* GMSOpeningHours.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086426526AE900C2AD24 /* GMSPlacePhotoMetadataList.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086526526AE900C2AD24 /* GMSPlacesClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086626526AE900C2AD24 /* GMSPlaceFieldMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086726526AE900C2AD24 /* GMSPlaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086826526AE900C2AD24 /* GMSAutocompleteResultsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086926526AE900C2AD24 /* GMSAutocompleteFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086A26526AE900C2AD24 /* GMSAddressComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085226526AE900C2AD24 /* GMSAddressComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086B26526AE900C2AD24 /* GMSPlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085326526AE900C2AD24 /* GMSPlace.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086C26526AE900C2AD24 /* GMSPlaceLikelihood.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
+		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8A6640D025398123000E9321 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8A8C8EE125387A0C00F5C247 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A8C8EFB25387A3E00F5C247;
+			remoteInfo = GoogleMapsBase;
+		};
+		8A6640D225398123000E9321 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8A8C8EE125387A0C00F5C247 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8A8C8F0A25387A4B00F5C247;
+			remoteInfo = GoogleMapsCore;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Google.h"; sourceTree = "<group>"; };
+		0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+Google.h"; sourceTree = "<group>"; };
+		0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSPolygon+Google.h"; sourceTree = "<group>"; };
+		0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSServices+Google.h"; sourceTree = "<group>"; };
+		0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStampStyle+Google.h"; sourceTree = "<group>"; };
+		0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStrokeStyle+Google.h"; sourceTree = "<group>"; };
+		0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSUISettings+Google.h"; sourceTree = "<group>"; };
+		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
+		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
+		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
+		8A663FE425397D2B000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
+		8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSDeprecationMacros.h; sourceTree = "<group>"; };
+		8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMapsBase.h; sourceTree = "<group>"; };
+		8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCompatabilityMacros.h; sourceTree = "<group>"; };
+		8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCoordinateBounds.h; sourceTree = "<group>"; };
+		8A663FFF25397D6F000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		8A66400A25397D7D000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
+		8A66401325397D90000E9321 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		8A66401525397D90000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
+		8A66401F25397DA0000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
+		8A6641102539828D000E9321 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		8A66411D253982C0000E9321 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		8A664124253982D0000E9321 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		8A664126253982D9000E9321 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		8A66412D253982E8000E9321 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		8A664134253982F1000E9321 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		8A66413B253982FB000E9321 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		8A66413D25398302000E9321 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		8A66414F25398315000E9321 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		8A66415C2539834F000E9321 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		8A66416F25398371000E9321 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		8A66417725398383000E9321 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		8A66417E2539838B000E9321 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
+		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
+		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
+		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
+		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
+		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
+		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
+		8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Premium.h"; sourceTree = "<group>"; };
+		8A7107E526526A8E00C2AD24 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
+		8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapID+Premium.h"; sourceTree = "<group>"; };
+		8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
+		8A7107E826526A8F00C2AD24 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
+		8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
+		8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
+		8A7107EC26526A8F00C2AD24 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
+		8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
+		8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
+		8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
+		8A7107F026526A8F00C2AD24 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
+		8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
+		8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
+		8A7107F326526A8F00C2AD24 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
+		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
+		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
+		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
+		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
+		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
+		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
+		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
+		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
+		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
+		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
+		8A71080026526A8F00C2AD24 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
+		8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
+		8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
+		8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
+		8A71080426526A8F00C2AD24 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
+		8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
+		8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
+		8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
+		8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
+		8A71080926526A9000C2AD24 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
+		8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
+		8A71080B26526A9000C2AD24 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
+		8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
+		8A71080D26526A9000C2AD24 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
+		8A71083F26526AE800C2AD24 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
+		8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
+		8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
+		8A71084226526AE900C2AD24 /* GMSPlusCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlusCode.h; sourceTree = "<group>"; };
+		8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceViewportInfo.h; sourceTree = "<group>"; };
+		8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompletePrediction.h; sourceTree = "<group>"; };
+		8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFetcher.h; sourceTree = "<group>"; };
+		8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteSessionToken.h; sourceTree = "<group>"; };
+		8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteTableDataSource.h; sourceTree = "<group>"; };
+		8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteMatchFragment.h; sourceTree = "<group>"; };
+		8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihoodList.h; sourceTree = "<group>"; };
+		8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadata.h; sourceTree = "<group>"; };
+		8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOpeningHours.h; sourceTree = "<group>"; };
+		8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadataList.h; sourceTree = "<group>"; };
+		8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesClient.h; sourceTree = "<group>"; };
+		8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceFieldMask.h; sourceTree = "<group>"; };
+		8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceTypes.h; sourceTree = "<group>"; };
+		8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteResultsViewController.h; sourceTree = "<group>"; };
+		8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFilter.h; sourceTree = "<group>"; };
+		8A71085226526AE900C2AD24 /* GMSAddressComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddressComponent.h; sourceTree = "<group>"; };
+		8A71085326526AE900C2AD24 /* GMSPlace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlace.h; sourceTree = "<group>"; };
+		8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihood.h; sourceTree = "<group>"; };
+		8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteViewController.h; sourceTree = "<group>"; };
+		8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesErrors.h; sourceTree = "<group>"; };
+		8A8B4E8E278317090014EB33 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		8A8C8EEA25387A0C00F5C247 /* GoogleMaps.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMaps.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A8C8EEE25387A0C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMapsBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A8C8EFF25387A3E00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8A8C8F0B25387A4B00F5C247 /* GoogleMapsCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMapsCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A8C8F0E25387A4B00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8A8C8F1B25387A5800F5C247 /* GoogleMapsM4B.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMapsM4B.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8A8C8EE725387A0C00F5C247 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A6641D425398415000E9321 /* libz.tbd in Frameworks */,
+				8A6641CE25398410000E9321 /* libc++.tbd in Frameworks */,
+				8A6641BE25398406000E9321 /* CoreImage.framework in Frameworks */,
+				8A6641B8253983F6000E9321 /* QuartzCore.framework in Frameworks */,
+				8A6641B2253983ED000E9321 /* ImageIO.framework in Frameworks */,
+				8A66416925398367000E9321 /* CoreGraphics.framework in Frameworks */,
+				8A66418E253983AA000E9321 /* SystemConfiguration.framework in Frameworks */,
+				8A6641872539839E000E9321 /* CoreLocation.framework in Frameworks */,
+				8A66418625398396000E9321 /* CoreTelephony.framework in Frameworks */,
+				8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */,
+				8A66417F2539838B000E9321 /* CoreData.framework in Frameworks */,
+				8A66417825398383000E9321 /* OpenGLES.framework in Frameworks */,
+				8A66417125398376000E9321 /* CoreText.framework in Frameworks */,
+				8A66417025398371000E9321 /* GLKit.framework in Frameworks */,
+				8A66415625398342000E9321 /* UIKit.framework in Frameworks */,
+				8A6641112539828D000E9321 /* Foundation.framework in Frameworks */,
+				8A6640BB253980A2000E9321 /* GoogleMapsBase.framework in Frameworks */,
+				8A6640EE2539820E000E9321 /* GoogleMaps in Frameworks */,
+				8A66410A2539826E000E9321 /* GoogleMapsCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8EF925387A3E00F5C247 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A66415025398315000E9321 /* libz.tbd in Frameworks */,
+				8A66414925398310000E9321 /* libc++.tbd in Frameworks */,
+				8A66413E25398302000E9321 /* CoreText.framework in Frameworks */,
+				8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */,
+				8A66413C253982FB000E9321 /* Security.framework in Frameworks */,
+				8A664135253982F1000E9321 /* CoreTelephony.framework in Frameworks */,
+				8A664127253982D9000E9321 /* CoreLocation.framework in Frameworks */,
+				8A664125253982D1000E9321 /* CoreGraphics.framework in Frameworks */,
+				8A66411E253982C0000E9321 /* UIKit.framework in Frameworks */,
+				8A664117253982B6000E9321 /* Foundation.framework in Frameworks */,
+				8A66408B25397EC3000E9321 /* GoogleMapsBase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F0825387A4B00F5C247 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F1825387A5800F5C247 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A66421725398499000E9321 /* libc++.tbd in Frameworks */,
+				8A66421625398491000E9321 /* Foundation.framework in Frameworks */,
+				8A66409625397EF2000E9321 /* GoogleMapsM4B in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F2925387A7C00F5C247 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A6642052539847A000E9321 /* libc++.tbd in Frameworks */,
+				8A6641FA25398472000E9321 /* QuartzCore.framework in Frameworks */,
+				8A6641F425398461000E9321 /* CoreLocation.framework in Frameworks */,
+				8A6641E825398452000E9321 /* CoreGraphics.framework in Frameworks */,
+				8A6641E225398447000E9321 /* UIKit.framework in Frameworks */,
+				8A6641E125398442000E9321 /* Foundation.framework in Frameworks */,
+				8A6641DA2539842E000E9321 /* GoogleMapsBase.framework in Frameworks */,
+				8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */,
+				8A6640A125397EFE000E9321 /* GooglePlaces in Frameworks */,
+				8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8A08ACA7253998F10078DE66 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */,
+				8A7107EC26526A8F00C2AD24 /* GMSAddress.h */,
+				8A71080D26526A9000C2AD24 /* GMSCALayer.h */,
+				8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */,
+				8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */,
+				8A7107F326526A8F00C2AD24 /* GMSCircle.h */,
+				8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */,
+				8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */,
+				8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */,
+				8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */,
+				8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */,
+				8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */,
+				8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */,
+				8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */,
+				8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */,
+				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
+				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
+				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
+				0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */,
+				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
+				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
+				0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */,
+				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
+				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
+				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
+				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
+				8A7107E026526A8E00C2AD24 /* GMSOverlay.h */,
+				8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */,
+				8A7107F626526A8F00C2AD24 /* GMSPanorama.h */,
+				8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */,
+				8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */,
+				8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */,
+				8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */,
+				8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */,
+				8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */,
+				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
+				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
+				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
+				0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */,
+				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
+				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
+				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
+				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
+				0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */,
+				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
+				0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */,
+				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
+				0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */,
+				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
+				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
+				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
+				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
+				0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */,
+				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
+				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A08AD1B2539994E0078DE66 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				8A71085226526AE900C2AD24 /* GMSAddressComponent.h */,
+				8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */,
+				8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */,
+				8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */,
+				8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */,
+				8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */,
+				8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */,
+				8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */,
+				8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */,
+				8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */,
+				8A71085326526AE900C2AD24 /* GMSPlace.h */,
+				8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */,
+				8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */,
+				8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */,
+				8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */,
+				8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */,
+				8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */,
+				8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */,
+				8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */,
+				8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */,
+				8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */,
+				8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */,
+				8A71084226526AE900C2AD24 /* GMSPlusCode.h */,
+				8A71083F26526AE800C2AD24 /* GooglePlaces.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A663FE325397D2B000E9321 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8A663FE425397D2B000E9321 /* module.modulemap */,
+			);
+			name = Modules;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A663FE525397D36000E9321 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				8A08AD0F253999110078DE66 /* GoogleMaps.bundle */,
+			);
+			name = Resources;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A663FF925397D6F000E9321 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */,
+				8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */,
+				8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */,
+				8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A663FFE25397D6F000E9321 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8A663FFF25397D6F000E9321 /* module.modulemap */,
+			);
+			name = Modules;
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66400925397D7D000E9321 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8A66400A25397D7D000E9321 /* module.modulemap */,
+			);
+			name = Modules;
+			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66401225397D90000E9321 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				8A66401325397D90000E9321 /* GoogleMaps.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66401425397D90000E9321 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8A66401525397D90000E9321 /* module.modulemap */,
+			);
+			name = Modules;
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66401E25397DA0000E9321 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8A66401F25397DA0000E9321 /* module.modulemap */,
+			);
+			name = Modules;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66403A25397DA0000E9321 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				8A08AD542539996C0078DE66 /* GooglePlaces.bundle */,
+			);
+			name = Resources;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Resources";
+			sourceTree = SOURCE_ROOT;
+		};
+		8A66407425397E8C000E9321 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8A8B4E8E278317090014EB33 /* Metal.framework */,
+				8A664196253983BC000E9321 /* CoreImage.framework */,
+				8A66418F253983B1000E9321 /* ImageIO.framework */,
+				8A66418D253983AA000E9321 /* SystemConfiguration.framework */,
+				8A66417E2539838B000E9321 /* CoreData.framework */,
+				8A66417725398383000E9321 /* OpenGLES.framework */,
+				8A66416F25398371000E9321 /* GLKit.framework */,
+				8A66415C2539834F000E9321 /* QuartzCore.framework */,
+				8A66414F25398315000E9321 /* libz.tbd */,
+				8A66413D25398302000E9321 /* CoreText.framework */,
+				8A66413B253982FB000E9321 /* Security.framework */,
+				8A664134253982F1000E9321 /* CoreTelephony.framework */,
+				8A66412D253982E8000E9321 /* libc++.tbd */,
+				8A664126253982D9000E9321 /* CoreLocation.framework */,
+				8A664124253982D0000E9321 /* CoreGraphics.framework */,
+				8A66411D253982C0000E9321 /* UIKit.framework */,
+				8A6641102539828D000E9321 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8A8C8EE025387A0C00F5C247 = {
+			isa = PBXGroup;
+			children = (
+				8A8C8EEC25387A0C00F5C247 /* GoogleMaps */,
+				8A8C8EFD25387A3E00F5C247 /* GoogleMapsBase */,
+				8A8C8F0C25387A4B00F5C247 /* GoogleMapsCore */,
+				8A8C8F1C25387A5800F5C247 /* GoogleMapsM4B */,
+				8A8C8F2D25387A7C00F5C247 /* GooglePlaces */,
+				8A8C8EEB25387A0C00F5C247 /* Products */,
+				8A66407425397E8C000E9321 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		8A8C8EEB25387A0C00F5C247 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8EEA25387A0C00F5C247 /* GoogleMaps.framework */,
+				8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */,
+				8A8C8F0B25387A4B00F5C247 /* GoogleMapsCore.framework */,
+				8A8C8F1B25387A5800F5C247 /* GoogleMapsM4B.framework */,
+				8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8A8C8EEC25387A0C00F5C247 /* GoogleMaps */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8EEE25387A0C00F5C247 /* Info.plist */,
+				8A663F7D25397CE4000E9321 /* GoogleMaps */,
+				8A08ACA7253998F10078DE66 /* Headers */,
+				8A663FE325397D2B000E9321 /* Modules */,
+				8A663FE525397D36000E9321 /* Resources */,
+			);
+			path = GoogleMaps;
+			sourceTree = "<group>";
+		};
+		8A8C8EFD25387A3E00F5C247 /* GoogleMapsBase */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8EFF25387A3E00F5C247 /* Info.plist */,
+				8A663FF225397D68000E9321 /* GoogleMapsBase */,
+				8A663FF925397D6F000E9321 /* Headers */,
+				8A663FFE25397D6F000E9321 /* Modules */,
+			);
+			path = GoogleMapsBase;
+			sourceTree = "<group>";
+		};
+		8A8C8F0C25387A4B00F5C247 /* GoogleMapsCore */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8F0E25387A4B00F5C247 /* Info.plist */,
+				8A66400B25397D7D000E9321 /* GoogleMapsCore */,
+				8A66400925397D7D000E9321 /* Modules */,
+			);
+			path = GoogleMapsCore;
+			sourceTree = "<group>";
+		};
+		8A8C8F1C25387A5800F5C247 /* GoogleMapsM4B */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8F1E25387A5800F5C247 /* Info.plist */,
+				8A66401625397D90000E9321 /* GoogleMapsM4B */,
+				8A66401225397D90000E9321 /* Headers */,
+				8A66401425397D90000E9321 /* Modules */,
+			);
+			path = GoogleMapsM4B;
+			sourceTree = "<group>";
+		};
+		8A8C8F2D25387A7C00F5C247 /* GooglePlaces */ = {
+			isa = PBXGroup;
+			children = (
+				8A8C8F2F25387A7C00F5C247 /* Info.plist */,
+				8A66403925397DA0000E9321 /* GooglePlaces */,
+				8A08AD1B2539994E0078DE66 /* Headers */,
+				8A66401E25397DA0000E9321 /* Modules */,
+				8A66403A25397DA0000E9321 /* Resources */,
+			);
+			path = GooglePlaces;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		8A8C8EE525387A0C00F5C247 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
+				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
+				0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */,
+				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
+				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
+				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
+				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
+				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
+				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
+				0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */,
+				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
+				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
+				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
+				0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */,
+				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
+				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
+				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
+				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
+				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
+				0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */,
+				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
+				0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */,
+				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
+				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
+				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
+				8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */,
+				8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */,
+				8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */,
+				8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */,
+				8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */,
+				8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */,
+				8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */,
+				8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */,
+				8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */,
+				8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */,
+				8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */,
+				8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */,
+				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
+				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
+				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
+				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
+				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
+				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
+				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
+				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
+				0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */,
+				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
+				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
+				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
+				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
+				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
+				0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */,
+				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
+				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
+				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8EF725387A3E00F5C247 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A66400225397D6F000E9321 /* GMSCompatabilityMacros.h in Headers */,
+				8A66400325397D6F000E9321 /* GMSCoordinateBounds.h in Headers */,
+				8A66400025397D6F000E9321 /* GMSDeprecationMacros.h in Headers */,
+				8A66400125397D6F000E9321 /* GoogleMapsBase.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F0625387A4B00F5C247 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F1625387A5800F5C247 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A66401725397D90000E9321 /* GoogleMaps.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F2725387A7C00F5C247 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A71086226526AE900C2AD24 /* GMSPlacePhotoMetadata.h in Headers */,
+				8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */,
+				8A71085E26526AE900C2AD24 /* GMSAutocompleteSessionToken.h in Headers */,
+				8A71086326526AE900C2AD24 /* GMSOpeningHours.h in Headers */,
+				8A71086726526AE900C2AD24 /* GMSPlaceTypes.h in Headers */,
+				8A71086426526AE900C2AD24 /* GMSPlacePhotoMetadataList.h in Headers */,
+				8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */,
+				8A71086826526AE900C2AD24 /* GMSAutocompleteResultsViewController.h in Headers */,
+				8A71086626526AE900C2AD24 /* GMSPlaceFieldMask.h in Headers */,
+				8A71086B26526AE900C2AD24 /* GMSPlace.h in Headers */,
+				8A71085A26526AE900C2AD24 /* GMSPlusCode.h in Headers */,
+				8A71085B26526AE900C2AD24 /* GMSPlaceViewportInfo.h in Headers */,
+				8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */,
+				8A71086926526AE900C2AD24 /* GMSAutocompleteFilter.h in Headers */,
+				8A71085D26526AE900C2AD24 /* GMSAutocompleteFetcher.h in Headers */,
+				8A71086C26526AE900C2AD24 /* GMSPlaceLikelihood.h in Headers */,
+				8A71086126526AE900C2AD24 /* GMSPlaceLikelihoodList.h in Headers */,
+				8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */,
+				8A71086A26526AE900C2AD24 /* GMSAddressComponent.h in Headers */,
+				8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */,
+				8A71085C26526AE900C2AD24 /* GMSAutocompletePrediction.h in Headers */,
+				8A71086026526AE900C2AD24 /* GMSAutocompleteMatchFragment.h in Headers */,
+				8A71085F26526AE900C2AD24 /* GMSAutocompleteTableDataSource.h in Headers */,
+				8A71086526526AE900C2AD24 /* GMSPlacesClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		8A8C8EE925387A0C00F5C247 /* GoogleMaps */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A8C8EF225387A0D00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMaps" */;
+			buildPhases = (
+				8A8C8EE525387A0C00F5C247 /* Headers */,
+				8A8C8EE625387A0C00F5C247 /* Sources */,
+				8A8C8EE725387A0C00F5C247 /* Frameworks */,
+				8A8C8EE825387A0C00F5C247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8A6640D125398123000E9321 /* PBXTargetDependency */,
+				8A6640D325398123000E9321 /* PBXTargetDependency */,
+			);
+			name = GoogleMaps;
+			productName = GoogleMaps;
+			productReference = 8A8C8EEA25387A0C00F5C247 /* GoogleMaps.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8A8C8EFB25387A3E00F5C247 /* GoogleMapsBase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A8C8F0125387A3E00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsBase" */;
+			buildPhases = (
+				8A8C8EF725387A3E00F5C247 /* Headers */,
+				8A8C8EF825387A3E00F5C247 /* Sources */,
+				8A8C8EF925387A3E00F5C247 /* Frameworks */,
+				8A8C8EFA25387A3E00F5C247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GoogleMapsBase;
+			productName = GoogleMapsBase;
+			productReference = 8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8A8C8F0A25387A4B00F5C247 /* GoogleMapsCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A8C8F1025387A4B00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsCore" */;
+			buildPhases = (
+				8A8C8F0625387A4B00F5C247 /* Headers */,
+				8A8C8F0725387A4B00F5C247 /* Sources */,
+				8A8C8F0825387A4B00F5C247 /* Frameworks */,
+				8A8C8F0925387A4B00F5C247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GoogleMapsCore;
+			productName = GoogleMapsCore;
+			productReference = 8A8C8F0B25387A4B00F5C247 /* GoogleMapsCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8A8C8F1A25387A5800F5C247 /* GoogleMapsM4B */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A8C8F2025387A5800F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsM4B" */;
+			buildPhases = (
+				8A8C8F1625387A5800F5C247 /* Headers */,
+				8A8C8F1725387A5800F5C247 /* Sources */,
+				8A8C8F1825387A5800F5C247 /* Frameworks */,
+				8A8C8F1925387A5800F5C247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GoogleMapsM4B;
+			productName = GoogleMapsM4B;
+			productReference = 8A8C8F1B25387A5800F5C247 /* GoogleMapsM4B.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8A8C8F2B25387A7C00F5C247 /* GooglePlaces */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A8C8F3125387A7C00F5C247 /* Build configuration list for PBXNativeTarget "GooglePlaces" */;
+			buildPhases = (
+				8A8C8F2725387A7C00F5C247 /* Headers */,
+				8A8C8F2825387A7C00F5C247 /* Sources */,
+				8A8C8F2925387A7C00F5C247 /* Frameworks */,
+				8A8C8F2A25387A7C00F5C247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GooglePlaces;
+			productName = GooglePlaces;
+			productReference = 8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8A8C8EE125387A0C00F5C247 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					8A8C8EE925387A0C00F5C247 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					8A8C8EFB25387A3E00F5C247 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					8A8C8F0A25387A4B00F5C247 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					8A8C8F1A25387A5800F5C247 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+					8A8C8F2B25387A7C00F5C247 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 8A8C8EE425387A0C00F5C247 /* Build configuration list for PBXProject "GoogleMaps-Sim" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 8A8C8EE025387A0C00F5C247;
+			productRefGroup = 8A8C8EEB25387A0C00F5C247 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8A8C8EE925387A0C00F5C247 /* GoogleMaps */,
+				8A8C8EFB25387A3E00F5C247 /* GoogleMapsBase */,
+				8A8C8F0A25387A4B00F5C247 /* GoogleMapsCore */,
+				8A8C8F1A25387A5800F5C247 /* GoogleMapsM4B */,
+				8A8C8F2B25387A7C00F5C247 /* GooglePlaces */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8A8C8EE825387A0C00F5C247 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8EFA25387A3E00F5C247 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F0925387A4B00F5C247 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F1925387A5800F5C247 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F2A25387A7C00F5C247 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8A8C8EE625387A0C00F5C247 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8EF825387A3E00F5C247 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F0725387A4B00F5C247 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F1725387A5800F5C247 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8A8C8F2825387A7C00F5C247 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8A6640D125398123000E9321 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A8C8EFB25387A3E00F5C247 /* GoogleMapsBase */;
+			targetProxy = 8A6640D025398123000E9321 /* PBXContainerItemProxy */;
+		};
+		8A6640D325398123000E9321 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8A8C8F0A25387A4B00F5C247 /* GoogleMapsCore */;
+			targetProxy = 8A6640D225398123000E9321 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		8A66422225398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Simulator Release";
+		};
+		8A66422325398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMaps/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Simulator Release";
+		};
+		8A66422425398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Simulator Release";
+		};
+		8A66422525398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Simulator Release";
+		};
+		8A66422625398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Simulator Release";
+		};
+		8A66422725398783000E9321 /* Simulator Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GooglePlaces/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Simulator Release";
+		};
+		8A8C8EF025387A0D00F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		8A8C8EF125387A0D00F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8A8C8EF325387A0D00F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMaps/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A8C8EF425387A0D00F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMaps/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACH_O_TYPE = mh_dylib;
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		8A8C8F0225387A3E00F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A8C8F0325387A3E00F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		8A8C8F1125387A4B00F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A8C8F1225387A4B00F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		8A8C8F2125387A5800F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A8C8F2225387A5800F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		8A8C8F3225387A7C00F5C247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GooglePlaces/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A8C8F3325387A7C00F5C247 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 060000;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = GooglePlaces/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.0.0;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8A8C8EE425387A0C00F5C247 /* Build configuration list for PBXProject "GoogleMaps-Sim" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8EF025387A0D00F5C247 /* Debug */,
+				8A8C8EF125387A0D00F5C247 /* Release */,
+				8A66422225398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A8C8EF225387A0D00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMaps" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8EF325387A0D00F5C247 /* Debug */,
+				8A8C8EF425387A0D00F5C247 /* Release */,
+				8A66422325398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A8C8F0125387A3E00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsBase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8F0225387A3E00F5C247 /* Debug */,
+				8A8C8F0325387A3E00F5C247 /* Release */,
+				8A66422425398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A8C8F1025387A4B00F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8F1125387A4B00F5C247 /* Debug */,
+				8A8C8F1225387A4B00F5C247 /* Release */,
+				8A66422525398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A8C8F2025387A5800F5C247 /* Build configuration list for PBXNativeTarget "GoogleMapsM4B" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8F2125387A5800F5C247 /* Debug */,
+				8A8C8F2225387A5800F5C247 /* Release */,
+				8A66422625398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A8C8F3125387A7C00F5C247 /* Build configuration list for PBXNativeTarget "GooglePlaces" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A8C8F3225387A7C00F5C247 /* Debug */,
+				8A8C8F3325387A7C00F5C247 /* Release */,
+				8A66422725398783000E9321 /* Simulator Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 8A8C8EE125387A0C00F5C247 /* Project object */;
+}

--- a/GoogleMaps-Sim.xcodeproj/project.pbxproj
+++ b/GoogleMaps-Sim.xcodeproj/project.pbxproj
@@ -7,13 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -156,30 +149,23 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Google.h"; sourceTree = "<group>"; };
-		0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+Google.h"; sourceTree = "<group>"; };
-		0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSPolygon+Google.h"; sourceTree = "<group>"; };
-		0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSServices+Google.h"; sourceTree = "<group>"; };
-		0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStampStyle+Google.h"; sourceTree = "<group>"; };
-		0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStrokeStyle+Google.h"; sourceTree = "<group>"; };
-		0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSUISettings+Google.h"; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
-		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
+		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
 		8A663FE425397D2B000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
+		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
 		8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSDeprecationMacros.h; sourceTree = "<group>"; };
 		8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMapsBase.h; sourceTree = "<group>"; };
 		8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCompatabilityMacros.h; sourceTree = "<group>"; };
 		8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCoordinateBounds.h; sourceTree = "<group>"; };
 		8A663FFF25397D6F000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66400A25397D7D000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
+		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
 		8A66401325397D90000E9321 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
 		8A66401525397D90000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
+		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
 		8A66401F25397DA0000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
+		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
 		8A6641102539828D000E9321 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A66411D253982C0000E9321 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		8A664124253982D0000E9321 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -384,10 +370,8 @@
 				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
 				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
 				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */,
 				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
 				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */,
 				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
 				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
 				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
@@ -404,26 +388,21 @@
 				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
 				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
 				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */,
 				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
 				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
 				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
 				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */,
 				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */,
 				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */,
 				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
 				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
 				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
 				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */,
 				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
 				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Headers";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A08AD1B2539994E0078DE66 /* Headers */ = {
@@ -455,7 +434,7 @@
 				8A71083F26526AE800C2AD24 /* GooglePlaces.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Headers";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE325397D2B000E9321 /* Modules */ = {
@@ -464,7 +443,7 @@
 				8A663FE425397D2B000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE525397D36000E9321 /* Resources */ = {
@@ -473,7 +452,7 @@
 				8A08AD0F253999110078DE66 /* GoogleMaps.bundle */,
 			);
 			name = Resources;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FF925397D6F000E9321 /* Headers */ = {
@@ -485,7 +464,7 @@
 				8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Headers";
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FFE25397D6F000E9321 /* Modules */ = {
@@ -494,7 +473,7 @@
 				8A663FFF25397D6F000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules";
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66400925397D7D000E9321 /* Modules */ = {
@@ -503,7 +482,7 @@
 				8A66400A25397D7D000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules";
+			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401225397D90000E9321 /* Headers */ = {
@@ -512,7 +491,7 @@
 				8A66401325397D90000E9321 /* GoogleMaps.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Headers";
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401425397D90000E9321 /* Modules */ = {
@@ -521,7 +500,7 @@
 				8A66401525397D90000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules";
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401E25397DA0000E9321 /* Modules */ = {
@@ -530,7 +509,7 @@
 				8A66401F25397DA0000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66403A25397DA0000E9321 /* Resources */ = {
@@ -539,7 +518,7 @@
 				8A08AD542539996C0078DE66 /* GooglePlaces.bundle */,
 			);
 			name = Resources;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Resources";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66407425397E8C000E9321 /* Frameworks */ = {
@@ -656,26 +635,21 @@
 			files = (
 				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
 				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */,
 				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
 				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
 				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
 				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
 				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
 				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */,
 				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
 				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
 				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */,
 				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
 				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
 				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
 				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
 				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */,
 				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */,
 				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
 				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
 				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
@@ -699,13 +673,11 @@
 				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
 				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
 				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */,
 				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
 				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
 				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
 				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
 				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */,
 				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
 				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
 				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
@@ -1080,7 +1052,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1111,7 +1083,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1141,7 +1113,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1171,7 +1143,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1201,7 +1173,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1350,7 +1322,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1382,7 +1354,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1413,7 +1385,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1443,7 +1415,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1473,7 +1445,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1503,7 +1475,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1533,7 +1505,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1563,7 +1535,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1593,7 +1565,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1623,7 +1595,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/GoogleMaps-Sim.xcodeproj/project.pbxproj
+++ b/GoogleMaps-Sim.xcodeproj/project.pbxproj
@@ -7,6 +7,53 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2FC3E2FC285BB297009BD200 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2CD285BB297009BD200 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2FD285BB297009BD200 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2CE285BB297009BD200 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2FE285BB297009BD200 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2CF285BB297009BD200 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2FF285BB297009BD200 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D0285BB297009BD200 /* GMSMapID.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E300285BB297009BD200 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D1285BB297009BD200 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E301285BB297009BD200 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D2285BB297009BD200 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E302285BB297009BD200 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D3285BB297009BD200 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E303285BB297009BD200 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D4285BB297009BD200 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E304285BB297009BD200 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D5285BB297009BD200 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E305285BB297009BD200 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D6285BB297009BD200 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E306285BB297009BD200 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D7285BB297009BD200 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E307285BB297009BD200 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D8285BB297009BD200 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E308285BB297009BD200 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2D9285BB297009BD200 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E309285BB297009BD200 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DA285BB297009BD200 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30A285BB297009BD200 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DB285BB297009BD200 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30B285BB297009BD200 /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DC285BB297009BD200 /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30C285BB297009BD200 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DD285BB297009BD200 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30D285BB297009BD200 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DE285BB297009BD200 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30E285BB297009BD200 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2DF285BB297009BD200 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E30F285BB297009BD200 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E0285BB297009BD200 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E310285BB297009BD200 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E1285BB297009BD200 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E311285BB297009BD200 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E2285BB297009BD200 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E312285BB297009BD200 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E3285BB297009BD200 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E313285BB297009BD200 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E4285BB297009BD200 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E314285BB297009BD200 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E5285BB297009BD200 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E315285BB297009BD200 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E6285BB297009BD200 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E316285BB297009BD200 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E7285BB297009BD200 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E317285BB297009BD200 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E8285BB297009BD200 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E318285BB297009BD200 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2E9285BB297009BD200 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E319285BB297009BD200 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2EA285BB297009BD200 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31A285BB297009BD200 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2EB285BB297009BD200 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31B285BB297009BD200 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2EC285BB297009BD200 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31C285BB297009BD200 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2ED285BB297009BD200 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31D285BB297009BD200 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2EE285BB297009BD200 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31E285BB297009BD200 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2EF285BB297009BD200 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E31F285BB297009BD200 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F0285BB297009BD200 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E320285BB297009BD200 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F1285BB297009BD200 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E321285BB297009BD200 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F2285BB297009BD200 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E322285BB297009BD200 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F3285BB297009BD200 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E323285BB297009BD200 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F4285BB297009BD200 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E324285BB297009BD200 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F5285BB297009BD200 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E325285BB297009BD200 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F6285BB297009BD200 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E326285BB297009BD200 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F7285BB297009BD200 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E327285BB297009BD200 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F8285BB297009BD200 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E328285BB297009BD200 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2F9285BB297009BD200 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E329285BB297009BD200 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2FA285BB297009BD200 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E32A285BB297009BD200 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2FB285BB297009BD200 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -54,55 +101,8 @@
 		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
 		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
 		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
-		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
 		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
-		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E526526A8E00C2AD24 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E826526A8F00C2AD24 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EC26526A8F00C2AD24 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082126526A9000C2AD24 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F026526A8F00C2AD24 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F326526A8F00C2AD24 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080026526A8F00C2AD24 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080426526A8F00C2AD24 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080926526A9000C2AD24 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080B26526A9000C2AD24 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080D26526A9000C2AD24 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71083F26526AE800C2AD24 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -128,7 +128,6 @@
 		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
-		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,23 +148,70 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2FC3E2CD285BB297009BD200 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
+		2FC3E2CE285BB297009BD200 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
+		2FC3E2CF285BB297009BD200 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
+		2FC3E2D0285BB297009BD200 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
+		2FC3E2D1285BB297009BD200 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
+		2FC3E2D2285BB297009BD200 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
+		2FC3E2D3285BB297009BD200 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
+		2FC3E2D4285BB297009BD200 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
+		2FC3E2D5285BB297009BD200 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
+		2FC3E2D6285BB297009BD200 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
+		2FC3E2D7285BB297009BD200 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
+		2FC3E2D8285BB297009BD200 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
+		2FC3E2D9285BB297009BD200 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
+		2FC3E2DA285BB297009BD200 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
+		2FC3E2DB285BB297009BD200 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
+		2FC3E2DC285BB297009BD200 /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
+		2FC3E2DD285BB297009BD200 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
+		2FC3E2DE285BB297009BD200 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
+		2FC3E2DF285BB297009BD200 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
+		2FC3E2E0285BB297009BD200 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
+		2FC3E2E1285BB297009BD200 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
+		2FC3E2E2285BB297009BD200 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
+		2FC3E2E3285BB297009BD200 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
+		2FC3E2E4285BB297009BD200 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
+		2FC3E2E5285BB297009BD200 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
+		2FC3E2E6285BB297009BD200 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
+		2FC3E2E7285BB297009BD200 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
+		2FC3E2E8285BB297009BD200 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
+		2FC3E2E9285BB297009BD200 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
+		2FC3E2EA285BB297009BD200 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
+		2FC3E2EB285BB297009BD200 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
+		2FC3E2EC285BB297009BD200 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		2FC3E2ED285BB297009BD200 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
+		2FC3E2EE285BB297009BD200 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
+		2FC3E2EF285BB297009BD200 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
+		2FC3E2F0285BB297009BD200 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
+		2FC3E2F1285BB297009BD200 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
+		2FC3E2F2285BB297009BD200 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
+		2FC3E2F3285BB297009BD200 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
+		2FC3E2F4285BB297009BD200 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
+		2FC3E2F5285BB297009BD200 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
+		2FC3E2F6285BB297009BD200 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
+		2FC3E2F7285BB297009BD200 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
+		2FC3E2F8285BB297009BD200 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
+		2FC3E2F9285BB297009BD200 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
+		2FC3E2FA285BB297009BD200 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
+		2FC3E2FB285BB297009BD200 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
-		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
+		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
 		8A663FE425397D2B000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
+		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
 		8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSDeprecationMacros.h; sourceTree = "<group>"; };
 		8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMapsBase.h; sourceTree = "<group>"; };
 		8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCompatabilityMacros.h; sourceTree = "<group>"; };
 		8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCoordinateBounds.h; sourceTree = "<group>"; };
 		8A663FFF25397D6F000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66400A25397D7D000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
+		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
 		8A66401325397D90000E9321 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
 		8A66401525397D90000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
+		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
 		8A66401F25397DA0000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
+		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
 		8A6641102539828D000E9321 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A66411D253982C0000E9321 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		8A664124253982D0000E9321 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -182,53 +228,6 @@
 		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
-		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
-		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
-		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
-		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
-		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
-		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
-		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
-		8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Premium.h"; sourceTree = "<group>"; };
-		8A7107E526526A8E00C2AD24 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
-		8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapID+Premium.h"; sourceTree = "<group>"; };
-		8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
-		8A7107E826526A8F00C2AD24 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
-		8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
-		8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
-		8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
-		8A7107EC26526A8F00C2AD24 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
-		8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
-		8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
-		8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
-		8A7107F026526A8F00C2AD24 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
-		8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
-		8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
-		8A7107F326526A8F00C2AD24 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
-		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
-		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
-		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
-		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
-		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
-		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
-		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
-		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
-		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
-		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
-		8A71080026526A8F00C2AD24 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
-		8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
-		8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
-		8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
-		8A71080426526A8F00C2AD24 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
-		8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
-		8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
-		8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
-		8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
-		8A71080926526A9000C2AD24 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
-		8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
-		8A71080B26526A9000C2AD24 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
-		8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
-		8A71080D26526A9000C2AD24 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
 		8A71083F26526AE800C2AD24 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
 		8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
 		8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
@@ -264,7 +263,6 @@
 		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -349,60 +347,59 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		8A08ACA7253998F10078DE66 /* Headers */ = {
+		2FC3E2CC285BB297009BD200 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */,
-				8A7107EC26526A8F00C2AD24 /* GMSAddress.h */,
-				8A71080D26526A9000C2AD24 /* GMSCALayer.h */,
-				8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */,
-				8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */,
-				8A7107F326526A8F00C2AD24 /* GMSCircle.h */,
-				8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */,
-				8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */,
-				8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */,
-				8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */,
-				8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */,
-				8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */,
-				8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */,
-				8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */,
-				8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */,
-				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
-				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
-				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
-				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
-				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
-				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
-				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
-				8A7107E026526A8E00C2AD24 /* GMSOverlay.h */,
-				8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */,
-				8A7107F626526A8F00C2AD24 /* GMSPanorama.h */,
-				8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */,
-				8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */,
-				8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */,
-				8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */,
-				8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */,
-				8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */,
-				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
-				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
-				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
-				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
-				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
-				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
-				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
-				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
-				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
-				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
+				2FC3E2CD285BB297009BD200 /* GMSPanoramaView.h */,
+				2FC3E2CE285BB297009BD200 /* GMSAccessibilityLabels.h */,
+				2FC3E2CF285BB297009BD200 /* GMSIndoorBuilding.h */,
+				2FC3E2D0285BB297009BD200 /* GMSMapID.h */,
+				2FC3E2D1285BB297009BD200 /* GMSMarker.h */,
+				2FC3E2D2285BB297009BD200 /* GMSMapView.h */,
+				2FC3E2D3285BB297009BD200 /* GMSServices.h */,
+				2FC3E2D4285BB297009BD200 /* GMSIndoorDisplay.h */,
+				2FC3E2D5285BB297009BD200 /* GMSMarkerLayer.h */,
+				2FC3E2D6285BB297009BD200 /* GMSOverlayLayer.h */,
+				2FC3E2D7285BB297009BD200 /* GMSCameraUpdate.h */,
+				2FC3E2D8285BB297009BD200 /* GMSMapLayer.h */,
+				2FC3E2D9285BB297009BD200 /* GMSPolyline.h */,
+				2FC3E2DA285BB297009BD200 /* GMSMapView+Animation.h */,
+				2FC3E2DB285BB297009BD200 /* GMSOrientation.h */,
+				2FC3E2DC285BB297009BD200 /* GMSMarkerAnimation.h */,
+				2FC3E2DD285BB297009BD200 /* GMSPanoramaService.h */,
+				2FC3E2DE285BB297009BD200 /* GMSMapStyle.h */,
+				2FC3E2DF285BB297009BD200 /* GMSMutablePath.h */,
+				2FC3E2E0285BB297009BD200 /* GMSPanorama.h */,
+				2FC3E2E1285BB297009BD200 /* GMSIndoorLevel.h */,
+				2FC3E2E2285BB297009BD200 /* GMSCircle.h */,
+				2FC3E2E3285BB297009BD200 /* GMSCoordinateBounds+GoogleMaps.h */,
+				2FC3E2E4285BB297009BD200 /* GMSStampStyle.h */,
+				2FC3E2E5285BB297009BD200 /* GMSPanoramaSource.h */,
+				2FC3E2E6285BB297009BD200 /* GMSStyleSpan.h */,
+				2FC3E2E7285BB297009BD200 /* GMSTileLayer.h */,
+				2FC3E2E8285BB297009BD200 /* GMSPanoramaCameraUpdate.h */,
+				2FC3E2E9285BB297009BD200 /* GMSPanoramaCamera.h */,
+				2FC3E2EA285BB297009BD200 /* GMSCameraPosition.h */,
+				2FC3E2EB285BB297009BD200 /* GMSAddress.h */,
+				2FC3E2EC285BB297009BD200 /* GoogleMaps.h */,
+				2FC3E2ED285BB297009BD200 /* GMSOverlay.h */,
+				2FC3E2EE285BB297009BD200 /* GMSSyncTileLayer.h */,
+				2FC3E2EF285BB297009BD200 /* GMSGeometryUtils.h */,
+				2FC3E2F0285BB297009BD200 /* GMSPath.h */,
+				2FC3E2F1285BB297009BD200 /* GMSURLTileLayer.h */,
+				2FC3E2F2285BB297009BD200 /* GMSGeocoder.h */,
+				2FC3E2F3285BB297009BD200 /* GMSPanoramaLink.h */,
+				2FC3E2F4285BB297009BD200 /* GMSGroundOverlay.h */,
+				2FC3E2F5285BB297009BD200 /* GMSCALayer.h */,
+				2FC3E2F6285BB297009BD200 /* GMSStrokeStyle.h */,
+				2FC3E2F7285BB297009BD200 /* GMSPanoramaLayer.h */,
+				2FC3E2F8285BB297009BD200 /* GMSPolygon.h */,
+				2FC3E2F9285BB297009BD200 /* GMSProjection.h */,
+				2FC3E2FA285BB297009BD200 /* GMSPolygonLayer.h */,
+				2FC3E2FB285BB297009BD200 /* GMSUISettings.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Headers";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A08AD1B2539994E0078DE66 /* Headers */ = {
@@ -434,7 +431,7 @@
 				8A71083F26526AE800C2AD24 /* GooglePlaces.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Headers";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE325397D2B000E9321 /* Modules */ = {
@@ -443,7 +440,7 @@
 				8A663FE425397D2B000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE525397D36000E9321 /* Resources */ = {
@@ -452,7 +449,7 @@
 				8A08AD0F253999110078DE66 /* GoogleMaps.bundle */,
 			);
 			name = Resources;
-			path = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Resources";
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FF925397D6F000E9321 /* Headers */ = {
@@ -464,7 +461,7 @@
 				8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Headers";
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FFE25397D6F000E9321 /* Modules */ = {
@@ -473,7 +470,7 @@
 				8A663FFF25397D6F000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules";
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66400925397D7D000E9321 /* Modules */ = {
@@ -482,7 +479,7 @@
 				8A66400A25397D7D000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules";
+			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401225397D90000E9321 /* Headers */ = {
@@ -491,7 +488,7 @@
 				8A66401325397D90000E9321 /* GoogleMaps.h */,
 			);
 			name = Headers;
-			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Headers";
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401425397D90000E9321 /* Modules */ = {
@@ -500,7 +497,7 @@
 				8A66401525397D90000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules";
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401E25397DA0000E9321 /* Modules */ = {
@@ -509,7 +506,7 @@
 				8A66401F25397DA0000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66403A25397DA0000E9321 /* Resources */ = {
@@ -518,7 +515,7 @@
 				8A08AD542539996C0078DE66 /* GooglePlaces.bundle */,
 			);
 			name = Resources;
-			path = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Resources";
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66407425397E8C000E9321 /* Frameworks */ = {
@@ -575,7 +572,7 @@
 			children = (
 				8A8C8EEE25387A0C00F5C247 /* Info.plist */,
 				8A663F7D25397CE4000E9321 /* GoogleMaps */,
-				8A08ACA7253998F10078DE66 /* Headers */,
+				2FC3E2CC285BB297009BD200 /* Headers */,
 				8A663FE325397D2B000E9321 /* Modules */,
 				8A663FE525397D36000E9321 /* Resources */,
 			);
@@ -633,54 +630,53 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
-				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
-				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
-				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
-				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
-				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
-				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
-				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
-				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
-				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
-				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
-				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
-				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
-				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
-				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
-				8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */,
-				8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */,
-				8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */,
-				8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */,
-				8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */,
-				8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */,
-				8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */,
-				8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */,
-				8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */,
-				8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */,
-				8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */,
-				8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */,
-				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
-				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
-				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
-				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
-				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
-				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
-				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
-				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
-				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
-				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
-				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
-				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
-				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
-				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
+				2FC3E31B285BB297009BD200 /* GoogleMaps.h in Headers */,
+				2FC3E323285BB297009BD200 /* GMSGroundOverlay.h in Headers */,
+				2FC3E322285BB297009BD200 /* GMSPanoramaLink.h in Headers */,
+				2FC3E30E285BB297009BD200 /* GMSMutablePath.h in Headers */,
+				2FC3E30F285BB297009BD200 /* GMSPanorama.h in Headers */,
+				2FC3E311285BB297009BD200 /* GMSCircle.h in Headers */,
+				2FC3E31C285BB297009BD200 /* GMSOverlay.h in Headers */,
+				2FC3E303285BB297009BD200 /* GMSIndoorDisplay.h in Headers */,
+				2FC3E310285BB297009BD200 /* GMSIndoorLevel.h in Headers */,
+				2FC3E317285BB297009BD200 /* GMSPanoramaCameraUpdate.h in Headers */,
+				2FC3E319285BB297009BD200 /* GMSCameraPosition.h in Headers */,
+				2FC3E31E285BB297009BD200 /* GMSGeometryUtils.h in Headers */,
+				2FC3E30C285BB297009BD200 /* GMSPanoramaService.h in Headers */,
+				2FC3E304285BB297009BD200 /* GMSMarkerLayer.h in Headers */,
+				2FC3E30D285BB297009BD200 /* GMSMapStyle.h in Headers */,
+				2FC3E315285BB297009BD200 /* GMSStyleSpan.h in Headers */,
+				2FC3E329285BB297009BD200 /* GMSPolygonLayer.h in Headers */,
+				2FC3E2FD285BB297009BD200 /* GMSAccessibilityLabels.h in Headers */,
+				2FC3E312285BB297009BD200 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
+				2FC3E30B285BB297009BD200 /* GMSMarkerAnimation.h in Headers */,
+				2FC3E320285BB297009BD200 /* GMSURLTileLayer.h in Headers */,
+				2FC3E30A285BB297009BD200 /* GMSOrientation.h in Headers */,
+				2FC3E321285BB297009BD200 /* GMSGeocoder.h in Headers */,
+				2FC3E309285BB297009BD200 /* GMSMapView+Animation.h in Headers */,
+				2FC3E305285BB297009BD200 /* GMSOverlayLayer.h in Headers */,
+				2FC3E2FE285BB297009BD200 /* GMSIndoorBuilding.h in Headers */,
+				2FC3E314285BB297009BD200 /* GMSPanoramaSource.h in Headers */,
+				2FC3E300285BB297009BD200 /* GMSMarker.h in Headers */,
+				2FC3E2FF285BB297009BD200 /* GMSMapID.h in Headers */,
+				2FC3E32A285BB297009BD200 /* GMSUISettings.h in Headers */,
+				2FC3E302285BB297009BD200 /* GMSServices.h in Headers */,
+				2FC3E316285BB297009BD200 /* GMSTileLayer.h in Headers */,
+				2FC3E325285BB297009BD200 /* GMSStrokeStyle.h in Headers */,
+				2FC3E324285BB297009BD200 /* GMSCALayer.h in Headers */,
+				2FC3E31D285BB297009BD200 /* GMSSyncTileLayer.h in Headers */,
+				2FC3E31A285BB297009BD200 /* GMSAddress.h in Headers */,
+				2FC3E313285BB297009BD200 /* GMSStampStyle.h in Headers */,
+				2FC3E301285BB297009BD200 /* GMSMapView.h in Headers */,
+				2FC3E307285BB297009BD200 /* GMSMapLayer.h in Headers */,
+				2FC3E308285BB297009BD200 /* GMSPolyline.h in Headers */,
+				2FC3E2FC285BB297009BD200 /* GMSPanoramaView.h in Headers */,
+				2FC3E306285BB297009BD200 /* GMSCameraUpdate.h in Headers */,
+				2FC3E318285BB297009BD200 /* GMSPanoramaCamera.h in Headers */,
+				2FC3E328285BB297009BD200 /* GMSProjection.h in Headers */,
+				2FC3E327285BB297009BD200 /* GMSPolygon.h in Headers */,
+				2FC3E326285BB297009BD200 /* GMSPanoramaLayer.h in Headers */,
+				2FC3E31F285BB297009BD200 /* GMSPath.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1052,7 +1048,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1083,7 +1079,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1113,7 +1109,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1143,7 +1139,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1173,7 +1169,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1322,7 +1318,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1354,7 +1350,7 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-x86_64_arm64-simulator/GoogleMaps.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1385,7 +1381,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1415,7 +1411,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-x86_64_arm64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1445,7 +1441,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1475,7 +1471,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-x86_64_arm64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1505,7 +1501,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1535,7 +1531,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-x86_64_arm64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64_x86_64-simulator/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1565,7 +1561,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1595,7 +1591,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-x86_64_arm64-simulator/GooglePlaces.framework/Modules/module.modulemap";
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64_x86_64-simulator/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -1036,7 +1036,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1052,7 +1052,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1068,7 +1068,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1098,7 +1098,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1113,7 +1113,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1128,7 +1128,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1158,7 +1158,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1173,7 +1173,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1306,7 +1306,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1321,7 +1321,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1337,7 +1337,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1352,7 +1352,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1368,7 +1368,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1382,7 +1382,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1397,7 +1397,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1411,7 +1411,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1426,7 +1426,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1440,7 +1440,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1455,7 +1455,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1469,7 +1469,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1484,7 +1484,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1498,7 +1498,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1513,7 +1513,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1527,7 +1527,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1542,7 +1542,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1556,7 +1556,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1571,7 +1571,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050000;
+				CURRENT_PROJECT_VERSION = 050100;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1585,7 +1585,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.1.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081226526A9000C2AD24 /* GMSStampStyle+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E126526A8E00C2AD24 /* GMSStampStyle+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -82,12 +81,10 @@
 		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082826526A9000C2AD24 /* GMSMarker+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F726526A8F00C2AD24 /* GMSMarker+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082D26526A9000C2AD24 /* GMSStrokeStyle+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FC26526A8F00C2AD24 /* GMSStrokeStyle+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -129,6 +126,8 @@
 		8A71086C26526AE900C2AD24 /* GMSPlaceLikelihood.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
+		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -186,7 +185,6 @@
 		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
 		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
 		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
-		8A7107E126526A8E00C2AD24 /* GMSStampStyle+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStampStyle+Premium.h"; sourceTree = "<group>"; };
 		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
 		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
 		8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Premium.h"; sourceTree = "<group>"; };
@@ -208,12 +206,10 @@
 		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
 		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
 		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
-		8A7107F726526A8F00C2AD24 /* GMSMarker+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+Premium.h"; sourceTree = "<group>"; };
 		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
 		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
 		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
 		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
-		8A7107FC26526A8F00C2AD24 /* GMSStrokeStyle+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStrokeStyle+Premium.h"; sourceTree = "<group>"; };
 		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
 		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
 		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
@@ -255,6 +251,7 @@
 		8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihood.h; sourceTree = "<group>"; };
 		8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteViewController.h; sourceTree = "<group>"; };
 		8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesErrors.h; sourceTree = "<group>"; };
+		8A8B4E8E278317090014EB33 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		8A8C8EEA25387A0C00F5C247 /* GoogleMaps.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMaps.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8EEE25387A0C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMapsBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -265,6 +262,7 @@
 		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +279,7 @@
 				8A66418E253983AA000E9321 /* SystemConfiguration.framework in Frameworks */,
 				8A6641872539839E000E9321 /* CoreLocation.framework in Frameworks */,
 				8A66418625398396000E9321 /* CoreTelephony.framework in Frameworks */,
+				8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */,
 				8A66417F2539838B000E9321 /* CoreData.framework in Frameworks */,
 				8A66417825398383000E9321 /* OpenGLES.framework in Frameworks */,
 				8A66417125398376000E9321 /* CoreText.framework in Frameworks */,
@@ -371,7 +370,6 @@
 				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
 				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
 				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				8A7107F726526A8F00C2AD24 /* GMSMarker+Premium.h */,
 				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
 				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
 				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
@@ -391,9 +389,8 @@
 				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
 				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
 				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				8A7107E126526A8E00C2AD24 /* GMSStampStyle+Premium.h */,
+				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
 				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				8A7107FC26526A8F00C2AD24 /* GMSStrokeStyle+Premium.h */,
 				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
 				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
 				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
@@ -524,6 +521,7 @@
 		8A66407425397E8C000E9321 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8A8B4E8E278317090014EB33 /* Metal.framework */,
 				8A664196253983BC000E9321 /* CoreImage.framework */,
 				8A66418F253983B1000E9321 /* ImageIO.framework */,
 				8A66418D253983AA000E9321 /* SystemConfiguration.framework */,
@@ -634,18 +632,15 @@
 			files = (
 				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
 				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				8A71082826526A9000C2AD24 /* GMSMarker+Premium.h in Headers */,
 				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
 				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
 				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
 				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
 				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
 				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				8A71081226526A9000C2AD24 /* GMSStampStyle+Premium.h in Headers */,
 				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
 				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
 				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				8A71082D26526A9000C2AD24 /* GMSStrokeStyle+Premium.h in Headers */,
 				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
 				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
 				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
@@ -676,6 +671,7 @@
 				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
 				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
 				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
+				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
 				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
 				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
 				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
@@ -842,7 +838,7 @@
 		8A8C8EE125387A0C00F5C247 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					8A8C8EE925387A0C00F5C247 = {
 						CreatedOnToolsVersion = 12.0.1;
@@ -1036,7 +1032,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1052,7 +1048,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1068,7 +1064,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1083,7 +1079,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1098,7 +1094,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1113,7 +1109,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1128,7 +1124,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1143,7 +1139,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1306,7 +1302,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1321,7 +1317,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1337,7 +1333,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1352,7 +1348,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1368,7 +1364,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1382,7 +1378,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1397,7 +1393,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1411,7 +1407,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1426,7 +1422,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1440,7 +1436,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1455,7 +1451,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1469,7 +1465,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1484,7 +1480,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1498,7 +1494,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1513,7 +1509,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 050200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1527,7 +1523,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 5.2.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -149,6 +156,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Google.h"; sourceTree = "<group>"; };
+		0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+Google.h"; sourceTree = "<group>"; };
+		0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSPolygon+Google.h"; sourceTree = "<group>"; };
+		0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSServices+Google.h"; sourceTree = "<group>"; };
+		0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStampStyle+Google.h"; sourceTree = "<group>"; };
+		0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStrokeStyle+Google.h"; sourceTree = "<group>"; };
+		0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSUISettings+Google.h"; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
 		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
@@ -370,8 +384,10 @@
 				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
 				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
 				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
+				0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */,
 				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
 				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
+				0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */,
 				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
 				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
 				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
@@ -388,16 +404,21 @@
 				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
 				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
 				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
+				0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */,
 				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
 				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
 				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
 				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
+				0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */,
 				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
+				0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */,
 				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
+				0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */,
 				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
 				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
 				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
 				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
+				0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */,
 				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
 				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
 			);
@@ -635,21 +656,26 @@
 			files = (
 				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
 				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
+				0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */,
 				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
 				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
 				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
 				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
 				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
 				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
+				0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */,
 				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
 				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
 				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
+				0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */,
 				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
 				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
 				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
 				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
 				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
+				0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */,
 				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
+				0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */,
 				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
 				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
 				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
@@ -673,11 +699,13 @@
 				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
 				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
 				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
+				0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */,
 				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
 				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
 				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
 				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
 				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
+				0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */,
 				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
 				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
 				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -151,21 +151,21 @@
 /* Begin PBXFileReference section */
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
-		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = ../Carthage/Build/iOS/GoogleMaps.framework/GoogleMaps; sourceTree = "<group>"; };
+		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
 		8A663FE425397D2B000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = ../Carthage/Build/iOS/GoogleMapsBase.framework/GoogleMapsBase; sourceTree = "<group>"; };
+		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
 		8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSDeprecationMacros.h; sourceTree = "<group>"; };
 		8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMapsBase.h; sourceTree = "<group>"; };
 		8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCompatabilityMacros.h; sourceTree = "<group>"; };
 		8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCoordinateBounds.h; sourceTree = "<group>"; };
 		8A663FFF25397D6F000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66400A25397D7D000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = ../Carthage/Build/iOS/GoogleMapsCore.framework/GoogleMapsCore; sourceTree = "<group>"; };
+		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
 		8A66401325397D90000E9321 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
 		8A66401525397D90000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = ../Carthage/Build/iOS/GoogleMapsM4B.framework/GoogleMapsM4B; sourceTree = "<group>"; };
+		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
 		8A66401F25397DA0000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = ../Carthage/Build/iOS/GooglePlaces.framework/GooglePlaces; sourceTree = "<group>"; };
+		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
 		8A6641102539828D000E9321 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A66411D253982C0000E9321 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		8A664124253982D0000E9321 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -402,7 +402,7 @@
 				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
 			);
 			name = Headers;
-			path = Carthage/Build/iOS/GoogleMaps.framework/Headers;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A08AD1B2539994E0078DE66 /* Headers */ = {
@@ -434,7 +434,7 @@
 				8A71083F26526AE800C2AD24 /* GooglePlaces.h */,
 			);
 			name = Headers;
-			path = Carthage/Build/iOS/GooglePlaces.framework/Headers;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE325397D2B000E9321 /* Modules */ = {
@@ -443,7 +443,7 @@
 				8A663FE425397D2B000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = Carthage/Build/iOS/GoogleMaps.framework/Modules;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FE525397D36000E9321 /* Resources */ = {
@@ -452,7 +452,7 @@
 				8A08AD0F253999110078DE66 /* GoogleMaps.bundle */,
 			);
 			name = Resources;
-			path = Carthage/Build/iOS/GoogleMaps.framework/Resources;
+			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FF925397D6F000E9321 /* Headers */ = {
@@ -464,7 +464,7 @@
 				8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */,
 			);
 			name = Headers;
-			path = Carthage/Build/iOS/GoogleMapsBase.framework/Headers;
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A663FFE25397D6F000E9321 /* Modules */ = {
@@ -473,7 +473,7 @@
 				8A663FFF25397D6F000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = Carthage/Build/iOS/GoogleMapsBase.framework/Modules;
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66400925397D7D000E9321 /* Modules */ = {
@@ -482,7 +482,7 @@
 				8A66400A25397D7D000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = Carthage/Build/iOS/GoogleMapsCore.framework/Modules;
+			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401225397D90000E9321 /* Headers */ = {
@@ -491,7 +491,7 @@
 				8A66401325397D90000E9321 /* GoogleMaps.h */,
 			);
 			name = Headers;
-			path = Carthage/Build/iOS/GoogleMapsM4B.framework/Headers;
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401425397D90000E9321 /* Modules */ = {
@@ -500,7 +500,7 @@
 				8A66401525397D90000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules;
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401E25397DA0000E9321 /* Modules */ = {
@@ -509,7 +509,7 @@
 				8A66401F25397DA0000E9321 /* module.modulemap */,
 			);
 			name = Modules;
-			path = Carthage/Build/iOS/GooglePlaces.framework/Modules;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Modules";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66403A25397DA0000E9321 /* Resources */ = {
@@ -518,7 +518,7 @@
 				8A08AD542539996C0078DE66 /* GooglePlaces.bundle */,
 			);
 			name = Resources;
-			path = Carthage/Build/iOS/GooglePlaces.framework/Resources;
+			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66407425397E8C000E9321 /* Frameworks */ = {
@@ -1035,14 +1035,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1053,10 +1052,11 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1067,14 +1067,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1084,9 +1083,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1097,14 +1097,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1114,9 +1113,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1127,14 +1127,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1144,9 +1143,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1157,14 +1157,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -1174,9 +1173,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1305,10 +1305,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1322,10 +1322,11 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1336,10 +1337,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1353,10 +1354,11 @@
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1367,10 +1369,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1383,9 +1385,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1396,10 +1399,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1412,9 +1415,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1425,10 +1429,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1441,9 +1445,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1454,10 +1459,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1470,9 +1475,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1483,10 +1489,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1499,9 +1505,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1512,10 +1519,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1528,9 +1535,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1541,10 +1549,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1557,9 +1565,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1570,10 +1579,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5PL9B9HNUS;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1586,9 +1595,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.0.0;
-				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
+				MODULEMAP_FILE = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Modules/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
 		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
 		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
+		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
 		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
 		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -181,6 +182,7 @@
 		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
+		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
 		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
 		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
 		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
 				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
 				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
+				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
 				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
 				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
 				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
@@ -665,6 +668,7 @@
 				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
 				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
 				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
+				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
 				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
 				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
 				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
@@ -1017,7 +1021,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1032,7 +1036,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1041,14 +1045,14 @@
 				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1064,7 +1068,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1073,13 +1077,13 @@
 				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1094,7 +1098,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1103,13 +1107,13 @@
 				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1124,7 +1128,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1133,13 +1137,13 @@
 				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1154,7 +1158,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1163,13 +1167,13 @@
 				EXCLUDED_ARCHS = arm64;
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1231,7 +1235,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1287,7 +1291,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1302,7 +1306,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1310,14 +1314,14 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1333,7 +1337,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1341,14 +1345,14 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMaps/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMaps.framework/Modules/module.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMaps;
@@ -1364,7 +1368,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1372,13 +1376,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1393,7 +1397,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1401,13 +1405,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsBase/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsBase.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsBase;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1422,7 +1426,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1430,13 +1434,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1451,7 +1455,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1459,13 +1463,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsCore.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1480,7 +1484,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1488,13 +1492,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1509,7 +1513,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050200;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1517,13 +1521,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleMapsM4B/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.2.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GoogleMapsM4B.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GoogleMapsM4B;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1538,7 +1542,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1546,13 +1550,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1567,7 +1571,7 @@
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 050100;
+				CURRENT_PROJECT_VERSION = 060000;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5PL9B9HNUS;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1575,13 +1579,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GooglePlaces/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.1.0;
+				MARKETING_VERSION = 6.0.0;
 				MODULEMAP_FILE = Carthage/Build/iOS/GooglePlaces.framework/Modules/module.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yassir.ios.GooglePlaces;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -7,16 +7,82 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2FC3E266285BAF15009BD200 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E237285BAF15009BD200 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E267285BAF15009BD200 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E238285BAF15009BD200 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E268285BAF15009BD200 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E239285BAF15009BD200 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E269285BAF15009BD200 /* GMSMapID.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23A285BAF15009BD200 /* GMSMapID.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26A285BAF15009BD200 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23B285BAF15009BD200 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26B285BAF15009BD200 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23C285BAF15009BD200 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26C285BAF15009BD200 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23D285BAF15009BD200 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26D285BAF15009BD200 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23E285BAF15009BD200 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26E285BAF15009BD200 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E23F285BAF15009BD200 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E26F285BAF15009BD200 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E240285BAF15009BD200 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E270285BAF15009BD200 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E241285BAF15009BD200 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E271285BAF15009BD200 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E242285BAF15009BD200 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E272285BAF15009BD200 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E243285BAF15009BD200 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E273285BAF15009BD200 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E244285BAF15009BD200 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E274285BAF15009BD200 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E245285BAF15009BD200 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E275285BAF15009BD200 /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E246285BAF15009BD200 /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E276285BAF15009BD200 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E247285BAF15009BD200 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E277285BAF15009BD200 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E248285BAF15009BD200 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E278285BAF15009BD200 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E249285BAF15009BD200 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E279285BAF15009BD200 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24A285BAF15009BD200 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27A285BAF15009BD200 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24B285BAF15009BD200 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27B285BAF15009BD200 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24C285BAF15009BD200 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27C285BAF15009BD200 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24D285BAF15009BD200 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27D285BAF15009BD200 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24E285BAF15009BD200 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27E285BAF15009BD200 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E24F285BAF15009BD200 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E27F285BAF15009BD200 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E250285BAF15009BD200 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E280285BAF15009BD200 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E251285BAF15009BD200 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E281285BAF15009BD200 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E252285BAF15009BD200 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E282285BAF15009BD200 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E253285BAF15009BD200 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E283285BAF15009BD200 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E254285BAF15009BD200 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E284285BAF15009BD200 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E255285BAF15009BD200 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E285285BAF15009BD200 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E256285BAF15009BD200 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E286285BAF15009BD200 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E257285BAF15009BD200 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E287285BAF15009BD200 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E258285BAF15009BD200 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E288285BAF15009BD200 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E259285BAF15009BD200 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E289285BAF15009BD200 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25A285BAF15009BD200 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28A285BAF15009BD200 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25B285BAF15009BD200 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28B285BAF15009BD200 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25C285BAF15009BD200 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28C285BAF15009BD200 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25D285BAF15009BD200 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28D285BAF15009BD200 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25E285BAF15009BD200 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28E285BAF15009BD200 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E25F285BAF15009BD200 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E28F285BAF15009BD200 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E260285BAF15009BD200 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E290285BAF15009BD200 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E261285BAF15009BD200 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E291285BAF15009BD200 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E262285BAF15009BD200 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E292285BAF15009BD200 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E263285BAF15009BD200 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E293285BAF15009BD200 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E264285BAF15009BD200 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E294285BAF15009BD200 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E265285BAF15009BD200 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E298285BAFCF009BD200 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E297285BAFCF009BD200 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B2285BAFF0009BD200 /* GMSAutocompleteTableDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29A285BAFF0009BD200 /* GMSAutocompleteTableDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B3285BAFF0009BD200 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29B285BAFF0009BD200 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B4285BAFF0009BD200 /* GMSPlacePhotoMetadataList.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29C285BAFF0009BD200 /* GMSPlacePhotoMetadataList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B5285BAFF0009BD200 /* GMSPlaceLikelihoodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29D285BAFF0009BD200 /* GMSPlaceLikelihoodList.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B6285BAFF1009BD200 /* GMSAddressComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29E285BAFF0009BD200 /* GMSAddressComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B7285BAFF1009BD200 /* GMSAutocompleteFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E29F285BAFF0009BD200 /* GMSAutocompleteFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B8285BAFF1009BD200 /* GMSPlaceLikelihood.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A0285BAFF0009BD200 /* GMSPlaceLikelihood.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2B9285BAFF1009BD200 /* GMSOpeningHours.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A1285BAFF0009BD200 /* GMSOpeningHours.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BA285BAFF1009BD200 /* GMSAutocompleteFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A2285BAFF0009BD200 /* GMSAutocompleteFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BB285BAFF1009BD200 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A3285BAFF0009BD200 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BC285BAFF1009BD200 /* GMSAutocompleteMatchFragment.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A4285BAFF0009BD200 /* GMSAutocompleteMatchFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BD285BAFF1009BD200 /* GMSPlacePhotoMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A5285BAFF0009BD200 /* GMSPlacePhotoMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BE285BAFF1009BD200 /* GMSPlacesClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A6285BAFF0009BD200 /* GMSPlacesClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2BF285BAFF1009BD200 /* GMSPlaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A7285BAFF0009BD200 /* GMSPlaceTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C0285BAFF1009BD200 /* GMSPlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A8285BAFF0009BD200 /* GMSPlace.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C1285BAFF1009BD200 /* GMSPlaceViewportInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2A9285BAFF0009BD200 /* GMSPlaceViewportInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C2285BAFF1009BD200 /* GMSPlusCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AA285BAFF0009BD200 /* GMSPlusCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C3285BAFF1009BD200 /* GMSPlaceFieldMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AB285BAFF0009BD200 /* GMSPlaceFieldMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C4285BAFF1009BD200 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AC285BAFF0009BD200 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C5285BAFF1009BD200 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AD285BAFF0009BD200 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C6285BAFF1009BD200 /* GMSAutocompletePrediction.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AE285BAFF0009BD200 /* GMSAutocompletePrediction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C7285BAFF1009BD200 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2AF285BAFF0009BD200 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C8285BAFF1009BD200 /* GMSAutocompleteResultsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2B0285BAFF0009BD200 /* GMSAutocompleteResultsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FC3E2C9285BAFF1009BD200 /* GMSAutocompleteSessionToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC3E2B1285BAFF0009BD200 /* GMSAutocompleteSessionToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
-		8A66400025397D6F000E9321 /* GMSDeprecationMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A66400125397D6F000E9321 /* GoogleMapsBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A66400225397D6F000E9321 /* GMSCompatabilityMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A66400325397D6F000E9321 /* GMSCoordinateBounds.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A66401725397D90000E9321 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A66401325397D90000E9321 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A66408B25397EC3000E9321 /* GoogleMapsBase in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A663FF225397D68000E9321 /* GoogleMapsBase */; };
-		8A66409625397EF2000E9321 /* GoogleMapsM4B in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66401625397D90000E9321 /* GoogleMapsM4B */; };
 		8A6640A125397EFE000E9321 /* GooglePlaces in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66403925397DA0000E9321 /* GooglePlaces */; };
 		8A6640BB253980A2000E9321 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8C8EFC25387A3E00F5C247 /* GoogleMapsBase.framework */; };
 		8A6640EE2539820E000E9321 /* GoogleMaps in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A663F7D25397CE4000E9321 /* GoogleMaps */; };
@@ -54,81 +120,9 @@
 		8A6642052539847A000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
 		8A66421625398491000E9321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6641102539828D000E9321 /* Foundation.framework */; };
 		8A66421725398499000E9321 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66412D253982E8000E9321 /* libc++.tbd */; };
-		8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A7107D926525FB000C2AD24 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66413B253982FB000E9321 /* Security.framework */; };
 		8A7107DA26525FC000C2AD24 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66414F25398315000E9321 /* libz.tbd */; };
-		8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E026526A8E00C2AD24 /* GMSOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E526526A8E00C2AD24 /* GMSPolyline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E826526A8F00C2AD24 /* GMSOrientation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EC26526A8F00C2AD24 /* GMSAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082126526A9000C2AD24 /* GMSPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F026526A8F00C2AD24 /* GMSPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F326526A8F00C2AD24 /* GMSCircle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F626526A8F00C2AD24 /* GMSPanorama.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FA26526A8F00C2AD24 /* GMSServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080026526A8F00C2AD24 /* GMSMarker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080426526A8F00C2AD24 /* GMSProjection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080926526A9000C2AD24 /* GMSPolygon.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080B26526A9000C2AD24 /* GMSMapView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71080D26526A9000C2AD24 /* GMSCALayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71083F26526AE800C2AD24 /* GooglePlaces.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085A26526AE900C2AD24 /* GMSPlusCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084226526AE900C2AD24 /* GMSPlusCode.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085B26526AE900C2AD24 /* GMSPlaceViewportInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085C26526AE900C2AD24 /* GMSAutocompletePrediction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085D26526AE900C2AD24 /* GMSAutocompleteFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085E26526AE900C2AD24 /* GMSAutocompleteSessionToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71085F26526AE900C2AD24 /* GMSAutocompleteTableDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086026526AE900C2AD24 /* GMSAutocompleteMatchFragment.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086126526AE900C2AD24 /* GMSPlaceLikelihoodList.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086226526AE900C2AD24 /* GMSPlacePhotoMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086326526AE900C2AD24 /* GMSOpeningHours.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086426526AE900C2AD24 /* GMSPlacePhotoMetadataList.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086526526AE900C2AD24 /* GMSPlacesClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086626526AE900C2AD24 /* GMSPlaceFieldMask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086726526AE900C2AD24 /* GMSPlaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086826526AE900C2AD24 /* GMSAutocompleteResultsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086926526AE900C2AD24 /* GMSAutocompleteFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086A26526AE900C2AD24 /* GMSAddressComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085226526AE900C2AD24 /* GMSAddressComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086B26526AE900C2AD24 /* GMSPlace.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085326526AE900C2AD24 /* GMSPlace.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086C26526AE900C2AD24 /* GMSPlaceLikelihood.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A8B4E8F278317090014EB33 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8B4E8E278317090014EB33 /* Metal.framework */; };
-		8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,21 +143,88 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2FC3E237285BAF15009BD200 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
+		2FC3E238285BAF15009BD200 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
+		2FC3E239285BAF15009BD200 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
+		2FC3E23A285BAF15009BD200 /* GMSMapID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapID.h; sourceTree = "<group>"; };
+		2FC3E23B285BAF15009BD200 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
+		2FC3E23C285BAF15009BD200 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
+		2FC3E23D285BAF15009BD200 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
+		2FC3E23E285BAF15009BD200 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
+		2FC3E23F285BAF15009BD200 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
+		2FC3E240285BAF15009BD200 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
+		2FC3E241285BAF15009BD200 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
+		2FC3E242285BAF15009BD200 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
+		2FC3E243285BAF15009BD200 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
+		2FC3E244285BAF15009BD200 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
+		2FC3E245285BAF15009BD200 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
+		2FC3E246285BAF15009BD200 /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
+		2FC3E247285BAF15009BD200 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
+		2FC3E248285BAF15009BD200 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
+		2FC3E249285BAF15009BD200 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
+		2FC3E24A285BAF15009BD200 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
+		2FC3E24B285BAF15009BD200 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
+		2FC3E24C285BAF15009BD200 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
+		2FC3E24D285BAF15009BD200 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
+		2FC3E24E285BAF15009BD200 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
+		2FC3E24F285BAF15009BD200 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
+		2FC3E250285BAF15009BD200 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
+		2FC3E251285BAF15009BD200 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
+		2FC3E252285BAF15009BD200 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
+		2FC3E253285BAF15009BD200 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
+		2FC3E254285BAF15009BD200 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
+		2FC3E255285BAF15009BD200 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
+		2FC3E256285BAF15009BD200 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		2FC3E257285BAF15009BD200 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
+		2FC3E258285BAF15009BD200 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
+		2FC3E259285BAF15009BD200 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
+		2FC3E25A285BAF15009BD200 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
+		2FC3E25B285BAF15009BD200 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
+		2FC3E25C285BAF15009BD200 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
+		2FC3E25D285BAF15009BD200 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
+		2FC3E25E285BAF15009BD200 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
+		2FC3E25F285BAF15009BD200 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
+		2FC3E260285BAF15009BD200 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
+		2FC3E261285BAF15009BD200 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
+		2FC3E262285BAF15009BD200 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
+		2FC3E263285BAF15009BD200 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
+		2FC3E264285BAF15009BD200 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
+		2FC3E265285BAF15009BD200 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
+		2FC3E297285BAFCF009BD200 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
+		2FC3E29A285BAFF0009BD200 /* GMSAutocompleteTableDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteTableDataSource.h; sourceTree = "<group>"; };
+		2FC3E29B285BAFF0009BD200 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
+		2FC3E29C285BAFF0009BD200 /* GMSPlacePhotoMetadataList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadataList.h; sourceTree = "<group>"; };
+		2FC3E29D285BAFF0009BD200 /* GMSPlaceLikelihoodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihoodList.h; sourceTree = "<group>"; };
+		2FC3E29E285BAFF0009BD200 /* GMSAddressComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddressComponent.h; sourceTree = "<group>"; };
+		2FC3E29F285BAFF0009BD200 /* GMSAutocompleteFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFilter.h; sourceTree = "<group>"; };
+		2FC3E2A0285BAFF0009BD200 /* GMSPlaceLikelihood.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihood.h; sourceTree = "<group>"; };
+		2FC3E2A1285BAFF0009BD200 /* GMSOpeningHours.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOpeningHours.h; sourceTree = "<group>"; };
+		2FC3E2A2285BAFF0009BD200 /* GMSAutocompleteFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFetcher.h; sourceTree = "<group>"; };
+		2FC3E2A3285BAFF0009BD200 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
+		2FC3E2A4285BAFF0009BD200 /* GMSAutocompleteMatchFragment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteMatchFragment.h; sourceTree = "<group>"; };
+		2FC3E2A5285BAFF0009BD200 /* GMSPlacePhotoMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadata.h; sourceTree = "<group>"; };
+		2FC3E2A6285BAFF0009BD200 /* GMSPlacesClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesClient.h; sourceTree = "<group>"; };
+		2FC3E2A7285BAFF0009BD200 /* GMSPlaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceTypes.h; sourceTree = "<group>"; };
+		2FC3E2A8285BAFF0009BD200 /* GMSPlace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlace.h; sourceTree = "<group>"; };
+		2FC3E2A9285BAFF0009BD200 /* GMSPlaceViewportInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceViewportInfo.h; sourceTree = "<group>"; };
+		2FC3E2AA285BAFF0009BD200 /* GMSPlusCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlusCode.h; sourceTree = "<group>"; };
+		2FC3E2AB285BAFF0009BD200 /* GMSPlaceFieldMask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceFieldMask.h; sourceTree = "<group>"; };
+		2FC3E2AC285BAFF0009BD200 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
+		2FC3E2AD285BAFF0009BD200 /* GMSAutocompleteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteViewController.h; sourceTree = "<group>"; };
+		2FC3E2AE285BAFF0009BD200 /* GMSAutocompletePrediction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompletePrediction.h; sourceTree = "<group>"; };
+		2FC3E2AF285BAFF0009BD200 /* GMSPlacesErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesErrors.h; sourceTree = "<group>"; };
+		2FC3E2B0285BAFF0009BD200 /* GMSAutocompleteResultsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteResultsViewController.h; sourceTree = "<group>"; };
+		2FC3E2B1285BAFF0009BD200 /* GMSAutocompleteSessionToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteSessionToken.h; sourceTree = "<group>"; };
+		2FC3E2CA285BB01B009BD200 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = GoogleMapsM4B; path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = SOURCE_ROOT; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
 		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
 		8A663FE425397D2B000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A663FF225397D68000E9321 /* GoogleMapsBase */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsBase; path = "../Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/GoogleMapsBase"; sourceTree = "<group>"; };
-		8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSDeprecationMacros.h; sourceTree = "<group>"; };
-		8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMapsBase.h; sourceTree = "<group>"; };
-		8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCompatabilityMacros.h; sourceTree = "<group>"; };
-		8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCoordinateBounds.h; sourceTree = "<group>"; };
 		8A663FFF25397D6F000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66400A25397D7D000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66400B25397D7D000E9321 /* GoogleMapsCore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsCore; path = "../Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/GoogleMapsCore"; sourceTree = "<group>"; };
-		8A66401325397D90000E9321 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
 		8A66401525397D90000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		8A66401625397D90000E9321 /* GoogleMapsM4B */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMapsM4B; path = "../Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/GoogleMapsM4B"; sourceTree = "<group>"; };
 		8A66401F25397DA0000E9321 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		8A66403925397DA0000E9321 /* GooglePlaces */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GooglePlaces; path = "../Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/GooglePlaces"; sourceTree = "<group>"; };
 		8A6641102539828D000E9321 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -182,77 +243,6 @@
 		8A66418D253983AA000E9321 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8A66418F253983B1000E9321 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		8A664196253983BC000E9321 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
-		8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerAnimation.h; sourceTree = "<group>"; };
-		8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorBuilding.h; sourceTree = "<group>"; };
-		8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGroundOverlay.h; sourceTree = "<group>"; };
-		8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeometryUtils.h; sourceTree = "<group>"; };
-		8A7107E026526A8E00C2AD24 /* GMSOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlay.h; sourceTree = "<group>"; };
-		8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStyleSpan.h; sourceTree = "<group>"; };
-		8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraUpdate.h; sourceTree = "<group>"; };
-		8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Premium.h"; sourceTree = "<group>"; };
-		8A7107E526526A8E00C2AD24 /* GMSPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolyline.h; sourceTree = "<group>"; };
-		8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapID+Premium.h"; sourceTree = "<group>"; };
-		8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaView.h; sourceTree = "<group>"; };
-		8A7107E826526A8F00C2AD24 /* GMSOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOrientation.h; sourceTree = "<group>"; };
-		8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMutablePath.h; sourceTree = "<group>"; };
-		8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GoogleMaps.h; sourceTree = "<group>"; };
-		8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSTileLayer.h; sourceTree = "<group>"; };
-		8A7107EC26526A8F00C2AD24 /* GMSAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddress.h; sourceTree = "<group>"; };
-		8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStrokeStyle.h; sourceTree = "<group>"; };
-		8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCamera.h; sourceTree = "<group>"; };
-		8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Animation.h"; sourceTree = "<group>"; };
-		8A7107F026526A8F00C2AD24 /* GMSPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPath.h; sourceTree = "<group>"; };
-		8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygonLayer.h; sourceTree = "<group>"; };
-		8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaService.h; sourceTree = "<group>"; };
-		8A7107F326526A8F00C2AD24 /* GMSCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCircle.h; sourceTree = "<group>"; };
-		8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapStyle.h; sourceTree = "<group>"; };
-		8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapLayer.h; sourceTree = "<group>"; };
-		8A7107F626526A8F00C2AD24 /* GMSPanorama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanorama.h; sourceTree = "<group>"; };
-		8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaSource.h; sourceTree = "<group>"; };
-		8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorLevel.h; sourceTree = "<group>"; };
-		8A7107FA26526A8F00C2AD24 /* GMSServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSServices.h; sourceTree = "<group>"; };
-		8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSCoordinateBounds+GoogleMaps.h"; sourceTree = "<group>"; };
-		8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSUISettings.h; sourceTree = "<group>"; };
-		8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSGeocoder.h; sourceTree = "<group>"; };
-		8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCameraPosition.h; sourceTree = "<group>"; };
-		8A71080026526A8F00C2AD24 /* GMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarker.h; sourceTree = "<group>"; };
-		8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMarkerLayer.h; sourceTree = "<group>"; };
-		8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSIndoorDisplay.h; sourceTree = "<group>"; };
-		8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSSyncTileLayer.h; sourceTree = "<group>"; };
-		8A71080426526A8F00C2AD24 /* GMSProjection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSProjection.h; sourceTree = "<group>"; };
-		8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSURLTileLayer.h; sourceTree = "<group>"; };
-		8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLink.h; sourceTree = "<group>"; };
-		8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaLayer.h; sourceTree = "<group>"; };
-		8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAccessibilityLabels.h; sourceTree = "<group>"; };
-		8A71080926526A9000C2AD24 /* GMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPolygon.h; sourceTree = "<group>"; };
-		8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPanoramaCameraUpdate.h; sourceTree = "<group>"; };
-		8A71080B26526A9000C2AD24 /* GMSMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSMapView.h; sourceTree = "<group>"; };
-		8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOverlayLayer.h; sourceTree = "<group>"; };
-		8A71080D26526A9000C2AD24 /* GMSCALayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSCALayer.h; sourceTree = "<group>"; };
-		8A71083F26526AE800C2AD24 /* GooglePlaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GooglePlaces.h; sourceTree = "<group>"; };
-		8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesDeprecationUtils.h; sourceTree = "<group>"; };
-		8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLocationOptions.h; sourceTree = "<group>"; };
-		8A71084226526AE900C2AD24 /* GMSPlusCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlusCode.h; sourceTree = "<group>"; };
-		8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceViewportInfo.h; sourceTree = "<group>"; };
-		8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompletePrediction.h; sourceTree = "<group>"; };
-		8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFetcher.h; sourceTree = "<group>"; };
-		8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteSessionToken.h; sourceTree = "<group>"; };
-		8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteTableDataSource.h; sourceTree = "<group>"; };
-		8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteMatchFragment.h; sourceTree = "<group>"; };
-		8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihoodList.h; sourceTree = "<group>"; };
-		8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadata.h; sourceTree = "<group>"; };
-		8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSOpeningHours.h; sourceTree = "<group>"; };
-		8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacePhotoMetadataList.h; sourceTree = "<group>"; };
-		8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesClient.h; sourceTree = "<group>"; };
-		8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceFieldMask.h; sourceTree = "<group>"; };
-		8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceTypes.h; sourceTree = "<group>"; };
-		8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteResultsViewController.h; sourceTree = "<group>"; };
-		8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteFilter.h; sourceTree = "<group>"; };
-		8A71085226526AE900C2AD24 /* GMSAddressComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAddressComponent.h; sourceTree = "<group>"; };
-		8A71085326526AE900C2AD24 /* GMSPlace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlace.h; sourceTree = "<group>"; };
-		8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlaceLikelihood.h; sourceTree = "<group>"; };
-		8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSAutocompleteViewController.h; sourceTree = "<group>"; };
-		8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSPlacesErrors.h; sourceTree = "<group>"; };
 		8A8B4E8E278317090014EB33 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		8A8C8EEA25387A0C00F5C247 /* GoogleMaps.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleMaps.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8EEE25387A0C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -264,7 +254,6 @@
 		8A8C8F1E25387A5800F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A8C8F2C25387A7C00F5C247 /* GooglePlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GooglePlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8C8F2F25387A7C00F5C247 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GMSStampStyle.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -325,7 +314,6 @@
 			files = (
 				8A66421725398499000E9321 /* libc++.tbd in Frameworks */,
 				8A66421625398491000E9321 /* Foundation.framework in Frameworks */,
-				8A66409625397EF2000E9321 /* GoogleMapsM4B in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,89 +337,105 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		8A08ACA7253998F10078DE66 /* Headers */ = {
+		2FC3E236285BAF15009BD200 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				8A71080826526A8F00C2AD24 /* GMSAccessibilityLabels.h */,
-				8A7107EC26526A8F00C2AD24 /* GMSAddress.h */,
-				8A71080D26526A9000C2AD24 /* GMSCALayer.h */,
-				8A7107FF26526A8F00C2AD24 /* GMSCameraPosition.h */,
-				8A7107E326526A8E00C2AD24 /* GMSCameraUpdate.h */,
-				8A7107F326526A8F00C2AD24 /* GMSCircle.h */,
-				8A7107FB26526A8F00C2AD24 /* GMSCoordinateBounds+GoogleMaps.h */,
-				8A7107FE26526A8F00C2AD24 /* GMSGeocoder.h */,
-				8A7107DF26526A8E00C2AD24 /* GMSGeometryUtils.h */,
-				8A7107DE26526A8E00C2AD24 /* GMSGroundOverlay.h */,
-				8A7107DD26526A8E00C2AD24 /* GMSIndoorBuilding.h */,
-				8A71080226526A8F00C2AD24 /* GMSIndoorDisplay.h */,
-				8A7107F926526A8F00C2AD24 /* GMSIndoorLevel.h */,
-				8A7107E626526A8E00C2AD24 /* GMSMapID+Premium.h */,
-				8A7107F526526A8F00C2AD24 /* GMSMapLayer.h */,
-				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
-				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
-				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
-				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
-				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
-				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
-				8A7107E826526A8F00C2AD24 /* GMSOrientation.h */,
-				8A7107E026526A8E00C2AD24 /* GMSOverlay.h */,
-				8A71080C26526A9000C2AD24 /* GMSOverlayLayer.h */,
-				8A7107F626526A8F00C2AD24 /* GMSPanorama.h */,
-				8A7107EE26526A8F00C2AD24 /* GMSPanoramaCamera.h */,
-				8A71080A26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h */,
-				8A71080726526A8F00C2AD24 /* GMSPanoramaLayer.h */,
-				8A71080626526A8F00C2AD24 /* GMSPanoramaLink.h */,
-				8A7107F226526A8F00C2AD24 /* GMSPanoramaService.h */,
-				8A7107F826526A8F00C2AD24 /* GMSPanoramaSource.h */,
-				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
-				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
-				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
-				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
-				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
-				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
-				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
-				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
-				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
-				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
+				2FC3E237285BAF15009BD200 /* GMSPanoramaView.h */,
+				2FC3E238285BAF15009BD200 /* GMSAccessibilityLabels.h */,
+				2FC3E239285BAF15009BD200 /* GMSIndoorBuilding.h */,
+				2FC3E23A285BAF15009BD200 /* GMSMapID.h */,
+				2FC3E23B285BAF15009BD200 /* GMSMarker.h */,
+				2FC3E23C285BAF15009BD200 /* GMSMapView.h */,
+				2FC3E23D285BAF15009BD200 /* GMSServices.h */,
+				2FC3E23E285BAF15009BD200 /* GMSIndoorDisplay.h */,
+				2FC3E23F285BAF15009BD200 /* GMSMarkerLayer.h */,
+				2FC3E240285BAF15009BD200 /* GMSOverlayLayer.h */,
+				2FC3E241285BAF15009BD200 /* GMSCameraUpdate.h */,
+				2FC3E242285BAF15009BD200 /* GMSMapLayer.h */,
+				2FC3E243285BAF15009BD200 /* GMSPolyline.h */,
+				2FC3E244285BAF15009BD200 /* GMSMapView+Animation.h */,
+				2FC3E245285BAF15009BD200 /* GMSOrientation.h */,
+				2FC3E246285BAF15009BD200 /* GMSMarkerAnimation.h */,
+				2FC3E247285BAF15009BD200 /* GMSPanoramaService.h */,
+				2FC3E248285BAF15009BD200 /* GMSMapStyle.h */,
+				2FC3E249285BAF15009BD200 /* GMSMutablePath.h */,
+				2FC3E24A285BAF15009BD200 /* GMSPanorama.h */,
+				2FC3E24B285BAF15009BD200 /* GMSIndoorLevel.h */,
+				2FC3E24C285BAF15009BD200 /* GMSCircle.h */,
+				2FC3E24D285BAF15009BD200 /* GMSCoordinateBounds+GoogleMaps.h */,
+				2FC3E24E285BAF15009BD200 /* GMSStampStyle.h */,
+				2FC3E24F285BAF15009BD200 /* GMSPanoramaSource.h */,
+				2FC3E250285BAF15009BD200 /* GMSStyleSpan.h */,
+				2FC3E251285BAF15009BD200 /* GMSTileLayer.h */,
+				2FC3E252285BAF15009BD200 /* GMSPanoramaCameraUpdate.h */,
+				2FC3E253285BAF15009BD200 /* GMSPanoramaCamera.h */,
+				2FC3E254285BAF15009BD200 /* GMSCameraPosition.h */,
+				2FC3E255285BAF15009BD200 /* GMSAddress.h */,
+				2FC3E256285BAF15009BD200 /* GoogleMaps.h */,
+				2FC3E257285BAF15009BD200 /* GMSOverlay.h */,
+				2FC3E258285BAF15009BD200 /* GMSSyncTileLayer.h */,
+				2FC3E259285BAF15009BD200 /* GMSGeometryUtils.h */,
+				2FC3E25A285BAF15009BD200 /* GMSPath.h */,
+				2FC3E25B285BAF15009BD200 /* GMSURLTileLayer.h */,
+				2FC3E25C285BAF15009BD200 /* GMSGeocoder.h */,
+				2FC3E25D285BAF15009BD200 /* GMSPanoramaLink.h */,
+				2FC3E25E285BAF15009BD200 /* GMSGroundOverlay.h */,
+				2FC3E25F285BAF15009BD200 /* GMSCALayer.h */,
+				2FC3E260285BAF15009BD200 /* GMSStrokeStyle.h */,
+				2FC3E261285BAF15009BD200 /* GMSPanoramaLayer.h */,
+				2FC3E262285BAF15009BD200 /* GMSPolygon.h */,
+				2FC3E263285BAF15009BD200 /* GMSProjection.h */,
+				2FC3E264285BAF15009BD200 /* GMSPolygonLayer.h */,
+				2FC3E265285BAF15009BD200 /* GMSUISettings.h */,
 			);
 			name = Headers;
 			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
-		8A08AD1B2539994E0078DE66 /* Headers */ = {
+		2FC3E295285BAF82009BD200 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				8A71085226526AE900C2AD24 /* GMSAddressComponent.h */,
-				8A71084526526AE900C2AD24 /* GMSAutocompleteFetcher.h */,
-				8A71085126526AE900C2AD24 /* GMSAutocompleteFilter.h */,
-				8A71084826526AE900C2AD24 /* GMSAutocompleteMatchFragment.h */,
-				8A71084426526AE900C2AD24 /* GMSAutocompletePrediction.h */,
-				8A71085026526AE900C2AD24 /* GMSAutocompleteResultsViewController.h */,
-				8A71084626526AE900C2AD24 /* GMSAutocompleteSessionToken.h */,
-				8A71084726526AE900C2AD24 /* GMSAutocompleteTableDataSource.h */,
-				8A71085526526AE900C2AD24 /* GMSAutocompleteViewController.h */,
-				8A71084B26526AE900C2AD24 /* GMSOpeningHours.h */,
-				8A71085326526AE900C2AD24 /* GMSPlace.h */,
-				8A71084E26526AE900C2AD24 /* GMSPlaceFieldMask.h */,
-				8A71085426526AE900C2AD24 /* GMSPlaceLikelihood.h */,
-				8A71084926526AE900C2AD24 /* GMSPlaceLikelihoodList.h */,
-				8A71084126526AE900C2AD24 /* GMSPlaceLocationOptions.h */,
-				8A71084A26526AE900C2AD24 /* GMSPlacePhotoMetadata.h */,
-				8A71084C26526AE900C2AD24 /* GMSPlacePhotoMetadataList.h */,
-				8A71084D26526AE900C2AD24 /* GMSPlacesClient.h */,
-				8A71084026526AE800C2AD24 /* GMSPlacesDeprecationUtils.h */,
-				8A71085626526AE900C2AD24 /* GMSPlacesErrors.h */,
-				8A71084F26526AE900C2AD24 /* GMSPlaceTypes.h */,
-				8A71084326526AE900C2AD24 /* GMSPlaceViewportInfo.h */,
-				8A71084226526AE900C2AD24 /* GMSPlusCode.h */,
-				8A71083F26526AE800C2AD24 /* GooglePlaces.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		2FC3E296285BAFCF009BD200 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				2FC3E297285BAFCF009BD200 /* GoogleMaps.h */,
+			);
+			name = Headers;
+			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Headers";
+			sourceTree = SOURCE_ROOT;
+		};
+		2FC3E299285BAFF0009BD200 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				2FC3E29A285BAFF0009BD200 /* GMSAutocompleteTableDataSource.h */,
+				2FC3E29B285BAFF0009BD200 /* GMSPlaceLocationOptions.h */,
+				2FC3E29C285BAFF0009BD200 /* GMSPlacePhotoMetadataList.h */,
+				2FC3E29D285BAFF0009BD200 /* GMSPlaceLikelihoodList.h */,
+				2FC3E29E285BAFF0009BD200 /* GMSAddressComponent.h */,
+				2FC3E29F285BAFF0009BD200 /* GMSAutocompleteFilter.h */,
+				2FC3E2A0285BAFF0009BD200 /* GMSPlaceLikelihood.h */,
+				2FC3E2A1285BAFF0009BD200 /* GMSOpeningHours.h */,
+				2FC3E2A2285BAFF0009BD200 /* GMSAutocompleteFetcher.h */,
+				2FC3E2A3285BAFF0009BD200 /* GMSPlacesDeprecationUtils.h */,
+				2FC3E2A4285BAFF0009BD200 /* GMSAutocompleteMatchFragment.h */,
+				2FC3E2A5285BAFF0009BD200 /* GMSPlacePhotoMetadata.h */,
+				2FC3E2A6285BAFF0009BD200 /* GMSPlacesClient.h */,
+				2FC3E2A7285BAFF0009BD200 /* GMSPlaceTypes.h */,
+				2FC3E2A8285BAFF0009BD200 /* GMSPlace.h */,
+				2FC3E2A9285BAFF0009BD200 /* GMSPlaceViewportInfo.h */,
+				2FC3E2AA285BAFF0009BD200 /* GMSPlusCode.h */,
+				2FC3E2AB285BAFF0009BD200 /* GMSPlaceFieldMask.h */,
+				2FC3E2AC285BAFF0009BD200 /* GooglePlaces.h */,
+				2FC3E2AD285BAFF0009BD200 /* GMSAutocompleteViewController.h */,
+				2FC3E2AE285BAFF0009BD200 /* GMSAutocompletePrediction.h */,
+				2FC3E2AF285BAFF0009BD200 /* GMSPlacesErrors.h */,
+				2FC3E2B0285BAFF0009BD200 /* GMSAutocompleteResultsViewController.h */,
+				2FC3E2B1285BAFF0009BD200 /* GMSAutocompleteSessionToken.h */,
 			);
 			name = Headers;
 			path = "Carthage/Build/GooglePlaces.xcframework/ios-arm64/GooglePlaces.framework/Headers";
@@ -455,18 +459,6 @@
 			path = "Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources";
 			sourceTree = SOURCE_ROOT;
 		};
-		8A663FF925397D6F000E9321 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				8A663FFA25397D6F000E9321 /* GMSDeprecationMacros.h */,
-				8A663FFB25397D6F000E9321 /* GoogleMapsBase.h */,
-				8A663FFC25397D6F000E9321 /* GMSCompatabilityMacros.h */,
-				8A663FFD25397D6F000E9321 /* GMSCoordinateBounds.h */,
-			);
-			name = Headers;
-			path = "Carthage/Build/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Headers";
-			sourceTree = SOURCE_ROOT;
-		};
 		8A663FFE25397D6F000E9321 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
@@ -483,15 +475,6 @@
 			);
 			name = Modules;
 			path = "Carthage/Build/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules";
-			sourceTree = SOURCE_ROOT;
-		};
-		8A66401225397D90000E9321 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				8A66401325397D90000E9321 /* GoogleMaps.h */,
-			);
-			name = Headers;
-			path = "Carthage/Build/GoogleMapsM4B.xcframework/ios-arm64/GoogleMapsM4B.framework/Headers";
 			sourceTree = SOURCE_ROOT;
 		};
 		8A66401425397D90000E9321 /* Modules */ = {
@@ -575,7 +558,7 @@
 			children = (
 				8A8C8EEE25387A0C00F5C247 /* Info.plist */,
 				8A663F7D25397CE4000E9321 /* GoogleMaps */,
-				8A08ACA7253998F10078DE66 /* Headers */,
+				2FC3E236285BAF15009BD200 /* Headers */,
 				8A663FE325397D2B000E9321 /* Modules */,
 				8A663FE525397D36000E9321 /* Resources */,
 			);
@@ -586,8 +569,8 @@
 			isa = PBXGroup;
 			children = (
 				8A8C8EFF25387A3E00F5C247 /* Info.plist */,
+				2FC3E295285BAF82009BD200 /* Headers */,
 				8A663FF225397D68000E9321 /* GoogleMapsBase */,
-				8A663FF925397D6F000E9321 /* Headers */,
 				8A663FFE25397D6F000E9321 /* Modules */,
 			);
 			path = GoogleMapsBase;
@@ -607,8 +590,8 @@
 			isa = PBXGroup;
 			children = (
 				8A8C8F1E25387A5800F5C247 /* Info.plist */,
-				8A66401625397D90000E9321 /* GoogleMapsM4B */,
-				8A66401225397D90000E9321 /* Headers */,
+				2FC3E2CA285BB01B009BD200 /* GoogleMapsM4B */,
+				2FC3E296285BAFCF009BD200 /* Headers */,
 				8A66401425397D90000E9321 /* Modules */,
 			);
 			path = GoogleMapsM4B;
@@ -619,7 +602,7 @@
 			children = (
 				8A8C8F2F25387A7C00F5C247 /* Info.plist */,
 				8A66403925397DA0000E9321 /* GooglePlaces */,
-				8A08AD1B2539994E0078DE66 /* Headers */,
+				2FC3E299285BAFF0009BD200 /* Headers */,
 				8A66401E25397DA0000E9321 /* Modules */,
 				8A66403A25397DA0000E9321 /* Resources */,
 			);
@@ -633,54 +616,53 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
-				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
-				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
-				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
-				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
-				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
-				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
-				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
-				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
-				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
-				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
-				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
-				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
-				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
-				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
-				8A71083226526A9000C2AD24 /* GMSMarkerLayer.h in Headers */,
-				8A71082926526A9000C2AD24 /* GMSPanoramaSource.h in Headers */,
-				8A71081626526A9000C2AD24 /* GMSPolyline.h in Headers */,
-				8A71081526526A9000C2AD24 /* GMSMapView+Premium.h in Headers */,
-				8A71082026526A9000C2AD24 /* GMSMapView+Animation.h in Headers */,
-				8A71082F26526A9000C2AD24 /* GMSGeocoder.h in Headers */,
-				8A71082626526A9000C2AD24 /* GMSMapLayer.h in Headers */,
-				8A71081326526A9000C2AD24 /* GMSStyleSpan.h in Headers */,
-				8A71081B26526A9000C2AD24 /* GoogleMaps.h in Headers */,
-				8A71081926526A9000C2AD24 /* GMSOrientation.h in Headers */,
-				8A71081126526A9000C2AD24 /* GMSOverlay.h in Headers */,
-				8A71083A26526A9000C2AD24 /* GMSPolygon.h in Headers */,
-				8A71083926526A9000C2AD24 /* GMSAccessibilityLabels.h in Headers */,
-				8A71083E26526A9000C2AD24 /* GMSCALayer.h in Headers */,
-				8A71081F26526A9000C2AD24 /* GMSPanoramaCamera.h in Headers */,
-				8A6DC50627834B6A00F9553C /* GMSMarkerAnimation.h in Headers */,
-				8A71082426526A9000C2AD24 /* GMSCircle.h in Headers */,
-				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
-				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
-				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
-				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
-				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
-				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
-				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
-				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
-				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,
+				2FC3E28D285BAF15009BD200 /* GMSGroundOverlay.h in Headers */,
+				2FC3E28C285BAF15009BD200 /* GMSPanoramaLink.h in Headers */,
+				2FC3E278285BAF15009BD200 /* GMSMutablePath.h in Headers */,
+				2FC3E279285BAF15009BD200 /* GMSPanorama.h in Headers */,
+				2FC3E27B285BAF15009BD200 /* GMSCircle.h in Headers */,
+				2FC3E286285BAF15009BD200 /* GMSOverlay.h in Headers */,
+				2FC3E26D285BAF15009BD200 /* GMSIndoorDisplay.h in Headers */,
+				2FC3E27A285BAF15009BD200 /* GMSIndoorLevel.h in Headers */,
+				2FC3E281285BAF15009BD200 /* GMSPanoramaCameraUpdate.h in Headers */,
+				2FC3E283285BAF15009BD200 /* GMSCameraPosition.h in Headers */,
+				2FC3E288285BAF15009BD200 /* GMSGeometryUtils.h in Headers */,
+				2FC3E276285BAF15009BD200 /* GMSPanoramaService.h in Headers */,
+				2FC3E26E285BAF15009BD200 /* GMSMarkerLayer.h in Headers */,
+				2FC3E277285BAF15009BD200 /* GMSMapStyle.h in Headers */,
+				2FC3E27F285BAF15009BD200 /* GMSStyleSpan.h in Headers */,
+				2FC3E293285BAF15009BD200 /* GMSPolygonLayer.h in Headers */,
+				2FC3E267285BAF15009BD200 /* GMSAccessibilityLabels.h in Headers */,
+				2FC3E27C285BAF15009BD200 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
+				2FC3E275285BAF15009BD200 /* GMSMarkerAnimation.h in Headers */,
+				2FC3E28A285BAF15009BD200 /* GMSURLTileLayer.h in Headers */,
+				2FC3E274285BAF15009BD200 /* GMSOrientation.h in Headers */,
+				2FC3E28B285BAF15009BD200 /* GMSGeocoder.h in Headers */,
+				2FC3E273285BAF15009BD200 /* GMSMapView+Animation.h in Headers */,
+				2FC3E285285BAF15009BD200 /* GoogleMaps.h in Headers */,
+				2FC3E26F285BAF15009BD200 /* GMSOverlayLayer.h in Headers */,
+				2FC3E268285BAF15009BD200 /* GMSIndoorBuilding.h in Headers */,
+				2FC3E27E285BAF15009BD200 /* GMSPanoramaSource.h in Headers */,
+				2FC3E26A285BAF15009BD200 /* GMSMarker.h in Headers */,
+				2FC3E269285BAF15009BD200 /* GMSMapID.h in Headers */,
+				2FC3E294285BAF15009BD200 /* GMSUISettings.h in Headers */,
+				2FC3E26C285BAF15009BD200 /* GMSServices.h in Headers */,
+				2FC3E280285BAF15009BD200 /* GMSTileLayer.h in Headers */,
+				2FC3E28F285BAF15009BD200 /* GMSStrokeStyle.h in Headers */,
+				2FC3E28E285BAF15009BD200 /* GMSCALayer.h in Headers */,
+				2FC3E287285BAF15009BD200 /* GMSSyncTileLayer.h in Headers */,
+				2FC3E284285BAF15009BD200 /* GMSAddress.h in Headers */,
+				2FC3E27D285BAF15009BD200 /* GMSStampStyle.h in Headers */,
+				2FC3E26B285BAF15009BD200 /* GMSMapView.h in Headers */,
+				2FC3E271285BAF15009BD200 /* GMSMapLayer.h in Headers */,
+				2FC3E272285BAF15009BD200 /* GMSPolyline.h in Headers */,
+				2FC3E266285BAF15009BD200 /* GMSPanoramaView.h in Headers */,
+				2FC3E270285BAF15009BD200 /* GMSCameraUpdate.h in Headers */,
+				2FC3E282285BAF15009BD200 /* GMSPanoramaCamera.h in Headers */,
+				2FC3E292285BAF15009BD200 /* GMSProjection.h in Headers */,
+				2FC3E291285BAF15009BD200 /* GMSPolygon.h in Headers */,
+				2FC3E290285BAF15009BD200 /* GMSPanoramaLayer.h in Headers */,
+				2FC3E289285BAF15009BD200 /* GMSPath.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -688,10 +670,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A66400225397D6F000E9321 /* GMSCompatabilityMacros.h in Headers */,
-				8A66400325397D6F000E9321 /* GMSCoordinateBounds.h in Headers */,
-				8A66400025397D6F000E9321 /* GMSDeprecationMacros.h in Headers */,
-				8A66400125397D6F000E9321 /* GoogleMapsBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -706,7 +684,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A66401725397D90000E9321 /* GoogleMaps.h in Headers */,
+				2FC3E298285BAFCF009BD200 /* GoogleMaps.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -714,30 +692,30 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A71086226526AE900C2AD24 /* GMSPlacePhotoMetadata.h in Headers */,
-				8A71085726526AE900C2AD24 /* GooglePlaces.h in Headers */,
-				8A71085E26526AE900C2AD24 /* GMSAutocompleteSessionToken.h in Headers */,
-				8A71086326526AE900C2AD24 /* GMSOpeningHours.h in Headers */,
-				8A71086726526AE900C2AD24 /* GMSPlaceTypes.h in Headers */,
-				8A71086426526AE900C2AD24 /* GMSPlacePhotoMetadataList.h in Headers */,
-				8A71086D26526AE900C2AD24 /* GMSAutocompleteViewController.h in Headers */,
-				8A71086826526AE900C2AD24 /* GMSAutocompleteResultsViewController.h in Headers */,
-				8A71086626526AE900C2AD24 /* GMSPlaceFieldMask.h in Headers */,
-				8A71086B26526AE900C2AD24 /* GMSPlace.h in Headers */,
-				8A71085A26526AE900C2AD24 /* GMSPlusCode.h in Headers */,
-				8A71085B26526AE900C2AD24 /* GMSPlaceViewportInfo.h in Headers */,
-				8A71085926526AE900C2AD24 /* GMSPlaceLocationOptions.h in Headers */,
-				8A71086926526AE900C2AD24 /* GMSAutocompleteFilter.h in Headers */,
-				8A71085D26526AE900C2AD24 /* GMSAutocompleteFetcher.h in Headers */,
-				8A71086C26526AE900C2AD24 /* GMSPlaceLikelihood.h in Headers */,
-				8A71086126526AE900C2AD24 /* GMSPlaceLikelihoodList.h in Headers */,
-				8A71085826526AE900C2AD24 /* GMSPlacesDeprecationUtils.h in Headers */,
-				8A71086A26526AE900C2AD24 /* GMSAddressComponent.h in Headers */,
-				8A71086E26526AE900C2AD24 /* GMSPlacesErrors.h in Headers */,
-				8A71085C26526AE900C2AD24 /* GMSAutocompletePrediction.h in Headers */,
-				8A71086026526AE900C2AD24 /* GMSAutocompleteMatchFragment.h in Headers */,
-				8A71085F26526AE900C2AD24 /* GMSAutocompleteTableDataSource.h in Headers */,
-				8A71086526526AE900C2AD24 /* GMSPlacesClient.h in Headers */,
+				2FC3E2BD285BAFF1009BD200 /* GMSPlacePhotoMetadata.h in Headers */,
+				2FC3E2C9285BAFF1009BD200 /* GMSAutocompleteSessionToken.h in Headers */,
+				2FC3E2B7285BAFF1009BD200 /* GMSAutocompleteFilter.h in Headers */,
+				2FC3E2BE285BAFF1009BD200 /* GMSPlacesClient.h in Headers */,
+				2FC3E2BB285BAFF1009BD200 /* GMSPlacesDeprecationUtils.h in Headers */,
+				2FC3E2C1285BAFF1009BD200 /* GMSPlaceViewportInfo.h in Headers */,
+				2FC3E2C7285BAFF1009BD200 /* GMSPlacesErrors.h in Headers */,
+				2FC3E2C3285BAFF1009BD200 /* GMSPlaceFieldMask.h in Headers */,
+				2FC3E2B6285BAFF1009BD200 /* GMSAddressComponent.h in Headers */,
+				2FC3E2C0285BAFF1009BD200 /* GMSPlace.h in Headers */,
+				2FC3E2B3285BAFF0009BD200 /* GMSPlaceLocationOptions.h in Headers */,
+				2FC3E2BF285BAFF1009BD200 /* GMSPlaceTypes.h in Headers */,
+				2FC3E2BA285BAFF1009BD200 /* GMSAutocompleteFetcher.h in Headers */,
+				2FC3E2B2285BAFF0009BD200 /* GMSAutocompleteTableDataSource.h in Headers */,
+				2FC3E2B8285BAFF1009BD200 /* GMSPlaceLikelihood.h in Headers */,
+				2FC3E2C5285BAFF1009BD200 /* GMSAutocompleteViewController.h in Headers */,
+				2FC3E2C6285BAFF1009BD200 /* GMSAutocompletePrediction.h in Headers */,
+				2FC3E2C2285BAFF1009BD200 /* GMSPlusCode.h in Headers */,
+				2FC3E2BC285BAFF1009BD200 /* GMSAutocompleteMatchFragment.h in Headers */,
+				2FC3E2C8285BAFF1009BD200 /* GMSAutocompleteResultsViewController.h in Headers */,
+				2FC3E2B5285BAFF0009BD200 /* GMSPlaceLikelihoodList.h in Headers */,
+				2FC3E2B4285BAFF0009BD200 /* GMSPlacePhotoMetadataList.h in Headers */,
+				2FC3E2B9285BAFF1009BD200 /* GMSOpeningHours.h in Headers */,
+				2FC3E2C4285BAFF1009BD200 /* GooglePlaces.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -7,13 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A08AD10253999110078DE66 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD0F253999110078DE66 /* GoogleMaps.bundle */; };
 		8A08AD552539996C0078DE66 /* GooglePlaces.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8A08AD542539996C0078DE66 /* GooglePlaces.bundle */; };
 		8A08AD65253999DB0078DE66 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A66415C2539834F000E9321 /* QuartzCore.framework */; };
@@ -156,13 +149,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMapView+Google.h"; sourceTree = "<group>"; };
-		0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSMarker+Google.h"; sourceTree = "<group>"; };
-		0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSPolygon+Google.h"; sourceTree = "<group>"; };
-		0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSServices+Google.h"; sourceTree = "<group>"; };
-		0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStampStyle+Google.h"; sourceTree = "<group>"; };
-		0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSStrokeStyle+Google.h"; sourceTree = "<group>"; };
-		0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMSUISettings+Google.h"; sourceTree = "<group>"; };
 		8A08AD0F253999110078DE66 /* GoogleMaps.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleMaps.bundle; sourceTree = "<group>"; };
 		8A08AD542539996C0078DE66 /* GooglePlaces.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GooglePlaces.bundle; sourceTree = "<group>"; };
 		8A663F7D25397CE4000E9321 /* GoogleMaps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "compiled.mach-o.objfile"; name = GoogleMaps; path = "../Carthage/Build/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/GoogleMaps"; sourceTree = "<group>"; };
@@ -384,10 +370,8 @@
 				8A7107F426526A8F00C2AD24 /* GMSMapStyle.h */,
 				8A71080B26526A9000C2AD24 /* GMSMapView.h */,
 				8A7107EF26526A8F00C2AD24 /* GMSMapView+Animation.h */,
-				0F58D20E27C7E0690057DF3D /* GMSMapView+Google.h */,
 				8A7107E426526A8E00C2AD24 /* GMSMapView+Premium.h */,
 				8A71080026526A8F00C2AD24 /* GMSMarker.h */,
-				0F58D21027C7E0740057DF3D /* GMSMarker+Google.h */,
 				8A6DC50527834B6A00F9553C /* GMSMarkerAnimation.h */,
 				8A71080126526A8F00C2AD24 /* GMSMarkerLayer.h */,
 				8A7107E926526A8F00C2AD24 /* GMSMutablePath.h */,
@@ -404,21 +388,16 @@
 				8A7107E726526A8F00C2AD24 /* GMSPanoramaView.h */,
 				8A7107F026526A8F00C2AD24 /* GMSPath.h */,
 				8A71080926526A9000C2AD24 /* GMSPolygon.h */,
-				0F58D21227C7E0840057DF3D /* GMSPolygon+Google.h */,
 				8A7107F126526A8F00C2AD24 /* GMSPolygonLayer.h */,
 				8A7107E526526A8E00C2AD24 /* GMSPolyline.h */,
 				8A71080426526A8F00C2AD24 /* GMSProjection.h */,
 				8A7107FA26526A8F00C2AD24 /* GMSServices.h */,
-				0F58D21427C7E08D0057DF3D /* GMSServices+Google.h */,
 				8AD14F4E2783159400B1AB33 /* GMSStampStyle.h */,
-				0F58D21627C7E0950057DF3D /* GMSStampStyle+Google.h */,
 				8A7107ED26526A8F00C2AD24 /* GMSStrokeStyle.h */,
-				0F58D21827C7E09C0057DF3D /* GMSStrokeStyle+Google.h */,
 				8A7107E226526A8E00C2AD24 /* GMSStyleSpan.h */,
 				8A71080326526A8F00C2AD24 /* GMSSyncTileLayer.h */,
 				8A7107EB26526A8F00C2AD24 /* GMSTileLayer.h */,
 				8A7107FD26526A8F00C2AD24 /* GMSUISettings.h */,
-				0F58D21A27C7E0A70057DF3D /* GMSUISettings+Google.h */,
 				8A71080526526A8F00C2AD24 /* GMSURLTileLayer.h */,
 				8A7107EA26526A8F00C2AD24 /* GoogleMaps.h */,
 			);
@@ -656,26 +635,21 @@
 			files = (
 				8A71082B26526A9000C2AD24 /* GMSServices.h in Headers */,
 				8A71083526526A9000C2AD24 /* GMSProjection.h in Headers */,
-				0F58D20F27C7E0690057DF3D /* GMSMapView+Google.h in Headers */,
 				8A71083726526A9000C2AD24 /* GMSPanoramaLink.h in Headers */,
 				8A71083326526A9000C2AD24 /* GMSIndoorDisplay.h in Headers */,
 				8A71083126526A9000C2AD24 /* GMSMarker.h in Headers */,
 				8A71081E26526A9000C2AD24 /* GMSStrokeStyle.h in Headers */,
 				8A71082A26526A9000C2AD24 /* GMSIndoorLevel.h in Headers */,
 				8A71082226526A9000C2AD24 /* GMSPolygonLayer.h in Headers */,
-				0F58D21327C7E0840057DF3D /* GMSPolygon+Google.h in Headers */,
 				8A71083426526A9000C2AD24 /* GMSSyncTileLayer.h in Headers */,
 				8A71082326526A9000C2AD24 /* GMSPanoramaService.h in Headers */,
 				8A71081026526A9000C2AD24 /* GMSGeometryUtils.h in Headers */,
-				0F58D21527C7E08D0057DF3D /* GMSServices+Google.h in Headers */,
 				8A71081726526A9000C2AD24 /* GMSMapID+Premium.h in Headers */,
 				8A71082E26526A9000C2AD24 /* GMSUISettings.h in Headers */,
 				8A71081826526A9000C2AD24 /* GMSPanoramaView.h in Headers */,
 				8A71080F26526A9000C2AD24 /* GMSGroundOverlay.h in Headers */,
 				8A71081A26526A9000C2AD24 /* GMSMutablePath.h in Headers */,
-				0F58D21127C7E0740057DF3D /* GMSMarker+Google.h in Headers */,
 				8A71083B26526A9000C2AD24 /* GMSPanoramaCameraUpdate.h in Headers */,
-				0F58D21927C7E09C0057DF3D /* GMSStrokeStyle+Google.h in Headers */,
 				8A71082526526A9000C2AD24 /* GMSMapStyle.h in Headers */,
 				8A71080E26526A9000C2AD24 /* GMSIndoorBuilding.h in Headers */,
 				8A71083C26526A9000C2AD24 /* GMSMapView.h in Headers */,
@@ -699,13 +673,11 @@
 				8A71081426526A9000C2AD24 /* GMSCameraUpdate.h in Headers */,
 				8A71082C26526A9000C2AD24 /* GMSCoordinateBounds+GoogleMaps.h in Headers */,
 				8A71081C26526A9000C2AD24 /* GMSTileLayer.h in Headers */,
-				0F58D21B27C7E0A70057DF3D /* GMSUISettings+Google.h in Headers */,
 				8A71083026526A9000C2AD24 /* GMSCameraPosition.h in Headers */,
 				8A71083626526A9000C2AD24 /* GMSURLTileLayer.h in Headers */,
 				8AD14F4F2783159400B1AB33 /* GMSStampStyle.h in Headers */,
 				8A71081D26526A9000C2AD24 /* GMSAddress.h in Headers */,
 				8A71082126526A9000C2AD24 /* GMSPath.h in Headers */,
-				0F58D21727C7E0950057DF3D /* GMSStampStyle+Google.h in Headers */,
 				8A71083D26526A9000C2AD24 /* GMSOverlayLayer.h in Headers */,
 				8A71083826526A9000C2AD24 /* GMSPanoramaLayer.h in Headers */,
 				8A71082726526A9000C2AD24 /* GMSPanorama.h in Headers */,

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -29,40 +29,28 @@ let package = Package(
             targets: [
                 "GoogleMapsM4B"
             ]
-        ),
-        .library(
-            name: "GooglePlaces",
-            targets: [
-                "GooglePlaces",
-                "GoogleMapsBase"
-            ]
         )
     ],
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMaps.xcframework.zip",
-            checksum: "4c3cd74860f036211e5648fbebff8e278abe2dbab033e8be527f30100187e5fe"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMaps.xcframework.zip",
+            checksum: "e422a4056ff7093fdeb1fe9cfac3dbd9a757309c7b483b78277582e43fe231c5"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsBase.xcframework.zip",
-            checksum: "c28b1fff1b9b6e44b06f116e67b924fba529305111ae964bdead01475a668c66"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsBase.xcframework.zip",
+            checksum: "b941bb683c777528bb171225f7adf9715bdef2c28d6b7c47e5164e9e23316699"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsCore.xcframework.zip",
-            checksum: "e1388910af2d3897d027da02a4f6d1ad26cac3b68e275ef39e94460f5c016c13"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsCore.xcframework.zip",
+            checksum: "386e68a88629f7977f8a11b731d92e627349cabf46391d1bd333216a6adaedb5"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsM4B.xcframework.zip",
-            checksum: "83c2402ae8a78eb412d934cd0f4906e567291f4727c4ad4ec2a730db0d04d8f2"
-        ),
-        .binaryTarget(
-            name: "GooglePlaces",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GooglePlaces.xcframework.zip",
-            checksum: "28319e68972c7a1910f95663b62562560d45371dd86304f675f283bb21fc7f45"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsM4B.xcframework.zip",
+            checksum: "df025349f08b06cc14f61d0bf7a19939958483020d3708e5f7e89bac9239b10a"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMaps.xcframework.zip",
-            checksum: "cd775df376017bf507d3f0bdfc29a60ebbe35f58a44333a54a7786c07c546036"
+            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMaps.xcframework.zip",
+            checksum: "6a1d802448bbd7b6fd42bf6cacbee2c11c6638c73a3adf6cc0bab1bf60f40c56"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsBase.xcframework.zip",
-            checksum: "37bbaf7a16c9495a791166f2ea64835bd8506034deb2f0970ec2c70b98cb310f"
+            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsBase.xcframework.zip",
+            checksum: "710806d11321359f5ad46345bee8a7ac2f12ed1ac4451a313ede4318cc08e273"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsCore.xcframework.zip",
-            checksum: "3c628402426869708f2b160e51526b5088e8d7a398b454ec7cba2ba11729cdb2"
+            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsCore.xcframework.zip",
+            checksum: "77a7fb139426041f6b93d6b09a376bf9b38c376682ba7d835aa194e47ebd92db"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsM4B.xcframework.zip",
-            checksum: "3d7a6832b9f9a47b4ea2c82a982e5084411d8b1bf6371855edc1f434ddbe96c0"
+            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsM4B.xcframework.zip",
+            checksum: "75b39725bb50391745ae6ed6a62a2433936e130ba8259ca0d4220fc5eef43bc8"
         ),
         .binaryTarget(
             name: "GooglePlaces",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GooglePlaces.xcframework.zip",
-            checksum: "50ebe575f4612e0c52ad2d388dbe25c943b88c0bf9a9a016b340dcca711e6bc6"
+            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GooglePlaces.xcframework.zip",
+            checksum: "cc0be0211e030b9980cdfe3325a40a3bcfea32cce23c03de863e03bc9cfd9e76"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -29,28 +29,40 @@ let package = Package(
             targets: [
                 "GoogleMapsM4B"
             ]
+        ),
+        .library(
+            name: "GooglePlaces",
+            targets: [
+                "GooglePlaces",
+                "GoogleMapsBase"
+            ]
         )
     ],
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMaps.xcframework.zip",
-            checksum: "e422a4056ff7093fdeb1fe9cfac3dbd9a757309c7b483b78277582e43fe231c5"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMaps.xcframework.zip",
+            checksum: "cd775df376017bf507d3f0bdfc29a60ebbe35f58a44333a54a7786c07c546036"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsBase.xcframework.zip",
-            checksum: "b941bb683c777528bb171225f7adf9715bdef2c28d6b7c47e5164e9e23316699"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsBase.xcframework.zip",
+            checksum: "37bbaf7a16c9495a791166f2ea64835bd8506034deb2f0970ec2c70b98cb310f"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsCore.xcframework.zip",
-            checksum: "386e68a88629f7977f8a11b731d92e627349cabf46391d1bd333216a6adaedb5"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsCore.xcframework.zip",
+            checksum: "3c628402426869708f2b160e51526b5088e8d7a398b454ec7cba2ba11729cdb2"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.2.0/GoogleMapsM4B.xcframework.zip",
-            checksum: "df025349f08b06cc14f61d0bf7a19939958483020d3708e5f7e89bac9239b10a"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GoogleMapsM4B.xcframework.zip",
+            checksum: "3d7a6832b9f9a47b4ea2c82a982e5084411d8b1bf6371855edc1f434ddbe96c0"
+        ),
+        .binaryTarget(
+            name: "GooglePlaces",
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/6.0.0/GooglePlaces.xcframework.zip",
+            checksum: "50ebe575f4612e0c52ad2d388dbe25c943b88c0bf9a9a016b340dcca711e6bc6"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.0.0/GoogleMaps.xcframework.zip",
-            checksum: "a91877f99f5f588731c5b1662d3fff1471d5139e3c048763d901f4e2a4e84d5d"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMaps.xcframework.zip",
+            checksum: "4c3cd74860f036211e5648fbebff8e278abe2dbab033e8be527f30100187e5fe"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.0.0/GoogleMapsBase.xcframework.zip",
-            checksum: "bfffbfc750caae8cff22ed489720eff9d1efa58ebe883c058f6a6ce52d970205"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsBase.xcframework.zip",
+            checksum: "c28b1fff1b9b6e44b06f116e67b924fba529305111ae964bdead01475a668c66"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.0.0/GoogleMapsCore.xcframework.zip",
-            checksum: "192894bdaf54965bad8541784d4fff261779d1ad268d9df6ad28c3ad06fe7047"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsCore.xcframework.zip",
+            checksum: "e1388910af2d3897d027da02a4f6d1ad26cac3b68e275ef39e94460f5c016c13"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.0.0/GoogleMapsM4B.xcframework.zip",
-            checksum: "d63ff2a74acbc71a37f7a615de11ab47b6fe9c462b2e68feff764a7153e1a99c"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GoogleMapsM4B.xcframework.zip",
+            checksum: "83c2402ae8a78eb412d934cd0f4906e567291f4727c4ad4ec2a730db0d04d8f2"
         ),
         .binaryTarget(
             name: "GooglePlaces",
-            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.0.0/GooglePlaces.xcframework.zip",
-            checksum: "703694603a35710277f98425d7f7b24ba409524dfd7275fcce442478980a8bee"
+            url: "https://github.com/YAtechnologies/GoogleMaps-SP/releases/download/5.1.0/GooglePlaces.xcframework.zip",
+            checksum: "28319e68972c7a1910f95663b62562560d45371dd86304f675f283bb21fc7f45"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMaps.xcframework.zip",
-            checksum: "490f79815a41b45deaf6ca3fd744f487d9dfe0182f0d58fe9c60cdcbe706c6d4"
+            url: "https://github.com/goflink/GoogleMaps-SP/releases/download/6.2.1/GoogleMaps.xcframework.zip",
+            checksum: "ee46b827b3bdf15627470523f7661c6d1ea4c3fa969abdbff345d127560b1f0a"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsBase.xcframework.zip",
-            checksum: "68c31db3317caa0dd531aeb9c2b31fd8b92753158400a37189b4d31af007e842"
+            url: "https://github.com/goflink/GoogleMaps-SP/releases/download/6.2.1/GoogleMapsBase.xcframework.zip",
+            checksum: "63e6a17f8e7a3caeaa9fe5d8dc9de5e6678cec0f686a60d99de8ff217c50e417"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsCore.xcframework.zip",
-            checksum: "3bdc93bfba83967c28d7c7885ec1a6de9bfe5a2178e0785e378d664d440f1d8b"
+            url: "https://github.com/goflink/GoogleMaps-SP/releases/download/6.2.1/GoogleMapsCore.xcframework.zip",
+            checksum: "0b0b13a000b0f62be5e8832363df6e08f7055c2edf2e25d5a0cf006f1fcaa8e1"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsM4B.xcframework.zip",
-            checksum: "6e1253f8ad0524fafe7acf3a4de09207d1b1d656fb473feb56c9520ba9fec9e1"
+            url: "https://github.com/goflink/GoogleMaps-SP/releases/download/6.2.1/GoogleMapsM4B.xcframework.zip",
+            checksum: "3c5f29cb0238f92eb2201abc38b015bfe7317ace8e23aa5d3c09f52a0657800a"
         ),
         .binaryTarget(
             name: "GooglePlaces",
-            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GooglePlaces.xcframework.zip",
-            checksum: "d764794a07fbdc387fb59d7bb0aee0d44c2b8d7bc962a1e13d7f36c7efd435d9"
+            url: "https://github.com/goflink/GoogleMaps-SP/releases/download/6.2.1/GooglePlaces.xcframework.zip",
+            checksum: "ba970db85f9173beb5942981725989826fe2ec0d5ac39f0f068f4191e420cbed"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -41,28 +41,28 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "GoogleMaps",
-            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMaps.xcframework.zip",
-            checksum: "6a1d802448bbd7b6fd42bf6cacbee2c11c6638c73a3adf6cc0bab1bf60f40c56"
+            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMaps.xcframework.zip",
+            checksum: "490f79815a41b45deaf6ca3fd744f487d9dfe0182f0d58fe9c60cdcbe706c6d4"
         ),
         .binaryTarget(
             name: "GoogleMapsBase",
-            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsBase.xcframework.zip",
-            checksum: "710806d11321359f5ad46345bee8a7ac2f12ed1ac4451a313ede4318cc08e273"
+            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsBase.xcframework.zip",
+            checksum: "68c31db3317caa0dd531aeb9c2b31fd8b92753158400a37189b4d31af007e842"
         ),
         .binaryTarget(
             name: "GoogleMapsCore",
-            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsCore.xcframework.zip",
-            checksum: "77a7fb139426041f6b93d6b09a376bf9b38c376682ba7d835aa194e47ebd92db"
+            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsCore.xcframework.zip",
+            checksum: "3bdc93bfba83967c28d7c7885ec1a6de9bfe5a2178e0785e378d664d440f1d8b"
         ),
         .binaryTarget(
             name: "GoogleMapsM4B",
-            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GoogleMapsM4B.xcframework.zip",
-            checksum: "75b39725bb50391745ae6ed6a62a2433936e130ba8259ca0d4220fc5eef43bc8"
+            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GoogleMapsM4B.xcframework.zip",
+            checksum: "6e1253f8ad0524fafe7acf3a4de09207d1b1d656fb473feb56c9520ba9fec9e1"
         ),
         .binaryTarget(
             name: "GooglePlaces",
-            url: "https://github.com/dplisek/GoogleMaps-SP/releases/download/6.0.0-universal/GooglePlaces.xcframework.zip",
-            checksum: "cc0be0211e030b9980cdfe3325a40a3bcfea32cce23c03de863e03bc9cfd9e76"
+            url: "https://github.com/mthole/GoogleMaps-SP/releases/download/6.1.1-universal/GooglePlaces.xcframework.zip",
+            checksum: "d764794a07fbdc387fb59d7bb0aee0d44c2b8d7bc962a1e13d7f36c7efd435d9"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "5.0.0"))
+    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "5.1.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Maps Swift Package
 
 ## Requirements
-* [iOS 10.0](https://wikipedia.org/wiki/IOS_10) or later.
+* [iOS 11.0](https://wikipedia.org/wiki/IOS_11) or later.
 * [Xcode 12.0](https://developer.apple.com/xcode) or later.
 
 ## Installation
@@ -9,7 +9,7 @@
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "5.1.0"))
+    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "5.2.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Maps Swift Package
 
 ## Requirements
-* [iOS 11.0](https://wikipedia.org/wiki/IOS_11) or later.
+* [iOS 12.0](https://wikipedia.org/wiki/IOS_12) or later.
 * [Xcode 12.0](https://developer.apple.com/xcode) or later.
 
 ## Installation
@@ -9,7 +9,7 @@
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "5.2.0"))
+    .package(url: "https://github.com/YAtechnologies/GoogleMaps-SP.git", .upToNextMinor(from: "6.0.0"))
 ]
 ```
 

--- a/make_xcframework.sh
+++ b/make_xcframework.sh
@@ -19,7 +19,7 @@ function archive_project() {
 
   # Archive iOS Simulator project.
   xcodebuild archive\
-     -project "../$project_name.xcodeproj"\
+     -project "../$project_name-Sim.xcodeproj"\
      -scheme "$framework_name"\
      -configuration "Simulator Release"\
      -destination "generic/platform=iOS Simulator"\


### PR DESCRIPTION
- Sync with upstream (using https://github.com/mthole/GoogleMaps-SP)
- Update `Cartfile` in order to fetch the latest version of GoogleMaps and GooglePlaces. (`6.2.1`)
- Add missing headers to both projects. (`GoogleMaps.xcodeproj` and `GoogleMaps-Sim.xcodeproj`)
- Update `Package.swift` in order to add checksums of newly built frameworks.